### PR TITLE
Vortex benchmark touchups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,7 +2030,6 @@ dependencies = [
  "toml",
  "turbo_pfor_sys",
  "vortex",
- "vortex-file",
  "wav",
  "zstd",
 ]

--- a/pco_cli/Cargo.toml
+++ b/pco_cli/Cargo.toml
@@ -42,11 +42,10 @@ tabled = "0.18.0"
 serde = { version = "1.0.197", features = ["derive"] }
 tokio = { version = "1.44.2", features = ["rt-multi-thread"], optional = true }
 turbo_pfor_sys = { version = "0.1.3", optional = true }
-vortex-file = { version = "0.28.0", optional = true }
-vortex = { version = "0.28.0", optional = true }
+vortex = { version = "0.28.0", features = ["files"], optional = true }
 wav = { version = "1.0.0", optional = true }
 zstd = "0.13"
 
 [features]
 audio = ["wav"]
-full_bench = ["blosc2-src", "brotli", "once_cell", "q_compress", "rayon", "spdp_sys", "tokio", "turbo_pfor_sys", "vortex-file", "vortex"]
+full_bench = ["blosc2-src", "brotli", "once_cell", "q_compress", "rayon", "spdp_sys", "tokio", "turbo_pfor_sys", "vortex"]


### PR DESCRIPTION
Firstly, thank you for taking the time to benchmark Vortex!
I've removed the explicit compression as the writer will do that on its own, and slimmed the dependency by a bit. 
We're also planning on improving on some of the pain points here (Sync read/write, less copies when working with `&[u8]`).

Running `pcodec bench -c pco,vortex` on my macbook now shows:
```
╭──────────────────────┬────────┬──────────────┬───────────────┬─────────────────╮
│ dataset              │ codec  │  compress_dt │ decompress_dt │ compressed_size │
├──────────────────────┼────────┼──────────────┼───────────────┼─────────────────┤
│ i64_cents            │ pco    │  11.239875ms │    2.053458ms │          443472 │
│ i64_cents            │ vortex │   9.359812ms │    1.228125ms │          879908 │
│ i64_constant         │ pco    │    2.38127ms │     796.354µs │              79 │
│ i64_constant         │ vortex │   2.496874ms │    1.718708ms │            3420 │
│ f32_csum             │ pco    │  14.627063ms │    1.811458ms │         2049864 │
│ f32_csum             │ vortex │  10.587292ms │      996.25µs │         4004212 │
│ f64_decimal          │ pco    │  20.667458ms │    3.376353ms │         1714586 │
│ f64_decimal          │ vortex │   16.30377ms │    2.134354ms │         1757404 │
│ f64_diablo           │ pco    │  29.349583ms │    3.929375ms │         1850162 │
│ f64_diablo           │ vortex │  15.881083ms │    2.138354ms │         2133820 │
│ i64_dist_shift       │ pco    │  13.344479ms │    1.809812ms │         2532334 │
│ i64_dist_shift       │ vortex │  32.967042ms │    1.772458ms │         2819972 │
│ i64_dollars          │ pco    │  11.623874ms │      1.8285ms │          619758 │
│ i64_dollars          │ vortex │   8.418833ms │    1.132542ms │         1122508 │
│ i64_geo              │ pco    │  15.184208ms │    1.793375ms │         1430528 │
│ i64_geo              │ vortex │   9.924229ms │    1.862958ms │         1637468 │
│ f64_integers         │ pco    │  15.985333ms │    1.969583ms │         3814638 │
│ f64_integers         │ vortex │  18.968979ms │    2.756209ms │         4259772 │
│ i64_interl0          │ pco    │  32.530187ms │    3.534146ms │          891168 │
│ i64_interl0          │ vortex │   6.147521ms │    1.696854ms │         3758396 │
│ i64_interl1          │ pco    │  32.146812ms │      3.4685ms │          541270 │
│ i64_interl1          │ vortex │   6.895104ms │    2.467687ms │         3758836 │
│ i64_interl_scrambl1  │ pco    │  35.744167ms │     3.71552ms │         1106654 │
│ i64_interl_scrambl1  │ vortex │  10.019292ms │    1.792292ms │         3758836 │
│ f32_log_normal       │ pco    │  13.926979ms │    1.434875ms │         3199985 │
│ f32_log_normal       │ vortex │  11.630458ms │     946.771µs │         4004212 │
│ i64_lomax05          │ pco    │   14.21475ms │     1.69925ms │         1729681 │
│ i64_lomax05          │ vortex │   9.523813ms │    1.338145ms │         2772060 │
│ u32_lomax05          │ pco    │  12.884021ms │    1.381812ms │         1721828 │
│ u32_lomax05          │ vortex │   9.603604ms │     940.646µs │         2681436 │
│ i32_lomax05          │ pco    │  12.831458ms │    1.461374ms │         1721340 │
│ i32_lomax05          │ vortex │   9.918687ms │     930.437µs │         2681300 │
│ i64_millis           │ pco    │  14.538104ms │    1.258645ms │         3750155 │
│ i64_millis           │ vortex │  11.153937ms │    1.960833ms │         5008820 │
│ i64_near_linear      │ pco    │  15.810187ms │    2.093042ms │         2815874 │
│ i64_near_linear      │ vortex │  10.579146ms │    1.845604ms │         4633652 │
│ f16_normal           │ pco    │  12.675229ms │    1.380104ms │         1691993 │
│ f16_normal           │ vortex │  10.793208ms │     744.875µs │         2003204 │
│ f32_normal           │ pco    │  14.299791ms │    1.455395ms │         3319338 │
│ f32_normal           │ vortex │  12.209583ms │       932.5µs │         4004212 │
│ f64_normal           │ pco    │  15.808604ms │    2.466063ms │         6946258 │
│ f64_normal           │ vortex │  12.365917ms │    1.569333ms │         8006308 │
│ f64_quantized_normal │ pco    │  16.303687ms │    2.026854ms │         3321307 │
│ f64_quantized_normal │ vortex │  12.112396ms │      1.5775ms │         8006308 │
│ f64_radians          │ pco    │   9.935354ms │    1.928229ms │          125703 │
│ f64_radians          │ vortex │  10.002917ms │    1.536771ms │         8006308 │
│ i64_slow_cosine      │ pco    │   9.322979ms │    2.007937ms │          190044 │
│ i64_slow_cosine      │ vortex │   8.269375ms │     1.69075ms │         2258148 │
│ f64_slow_cosine      │ pco    │  22.001062ms │    3.607667ms │         1769241 │
│ f64_slow_cosine      │ vortex │   9.669667ms │    1.592375ms │         8006308 │
│ i64_sparse           │ pco    │   6.689646ms │    1.579688ms │           10251 │
│ i64_sparse           │ vortex │  11.652729ms │    1.353312ms │           43980 │
│ i64_total_cents      │ pco    │  14.508479ms │    1.810541ms │         1207743 │
│ i64_total_cents      │ vortex │   9.294604ms │      1.4145ms │         1928532 │
│ i64_uniform          │ pco    │  14.324375ms │    1.429437ms │         8000079 │
│ i64_uniform          │ vortex │   9.550292ms │    1.994688ms │         8005260 │
│ <sum>                │ pco    │ 454.899014ms │   59.107347ms │        58515333 │
│ <sum>                │ vortex │ 316.300164ms │   44.065831ms │       101944600 │
╰──────────────────────┴────────┴──────────────┴───────────────┴─────────────────╯
```