### PR TITLE
Warn if compiled on x64 in release without avx, bmi

### DIFF
--- a/pco/Cargo.toml
+++ b/pco/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pco"
 version = "0.4.2"
 edition = "2021"
+build = "build.rs"
 
 authors = ["mwlon <m.w.loncaric@gmail.com>"]
 categories = ["compression", "encoding"]

--- a/pco/build.rs
+++ b/pco/build.rs
@@ -1,0 +1,33 @@
+use std::env;
+
+const DISMISS_WARNINGS_VAR: &str = "PCO_DISMISS_BUILD_WARNINGS";
+
+fn main() {
+  if cfg!(target_arch = "x86_64")
+    && env::var("PROFILE").unwrap_or("".to_string()) == "release"
+    && env::var(DISMISS_WARNINGS_VAR).unwrap_or("".to_string()) != "1"
+  {
+    let mut missing_instructions = Vec::new();
+    if !cfg!(target_feature = "bmi1") {
+      missing_instructions.push("bmi1");
+    }
+    if !cfg!(target_feature = "bmi2") {
+      missing_instructions.push("bmi2");
+    }
+    if !cfg!(target_feature = "avx2") {
+      missing_instructions.push("avx2");
+    }
+
+    if missing_instructions.len() > 0 {
+      println!(
+        "cargo:warning=[pco] Building on x64 in release mode without the \
+        following instruction sets: {}. \
+        This can substantially hinder performance. \
+        Follow the instructions at https://github.com/pcodec/pcodec/tree/pco. \
+        To ignore: set {}=1",
+        missing_instructions.join(", "),
+        DISMISS_WARNINGS_VAR,
+      );
+    }
+  }
+}

--- a/pco/build.rs
+++ b/pco/build.rs
@@ -23,7 +23,8 @@ fn main() {
         "cargo:warning=[pco] Building on x64 in release mode without the \
         following instruction sets: {}. \
         This can substantially hinder performance. \
-        Follow the instructions at https://github.com/pcodec/pcodec/tree/pco. \
+        To fix: follow the instructions at \
+        https://github.com/pcodec/pcodec/tree/main/pco. \
         To ignore: set {}=1",
         missing_instructions.join(", "),
         DISMISS_WARNINGS_VAR,


### PR DESCRIPTION
I kept thinking about how to ensure good performance, since these instruction sets aren't enabled by default (at least on an old machine of mine that DOES support them). I considered forcing them to be on, without input from the user, but ultimately decided that would be confusing behavior and could cause problems if the user really doesn't have them. Instead I think this warning is the right middle ground, but open to input if there are other conventions out there.

I tried it out and got the warning as expected, and didn't get it when using the instruction sets.