### PR TITLE
use less PerLatentVarBuilder

### DIFF
--- a/pco/src/metadata/per_latent_var.rs
+++ b/pco/src/metadata/per_latent_var.rs
@@ -65,7 +65,7 @@ impl<T> From<PerLatentVarBuilder<T>> for PerLatentVar<T> {
 }
 
 impl<T> PerLatentVar<T> {
-  pub(crate) fn map<S, F: Fn(LatentVarKey, T) -> S>(self, f: F) -> PerLatentVar<S> {
+  pub(crate) fn map<S, F: FnMut(LatentVarKey, T) -> S>(self, mut f: F) -> PerLatentVar<S> {
     PerLatentVar {
       delta: self.delta.map(|delta| f(LatentVarKey::Delta, delta)),
       primary: f(LatentVarKey::Primary, self.primary),


### PR DESCRIPTION
Builder is more verbose than .map, and might copy the data in some cases.