### PR TITLE
heap allocate LatentPageDecompressors

### DIFF
--- a/pco/src/latent_page_decompressor.rs
+++ b/pco/src/latent_page_decompressor.rs
@@ -29,7 +29,6 @@ impl<L: Latent> BinDecompressionInfo<L> {
 #[derive(Clone, Debug)]
 struct State<L: Latent> {
   // scratch needs no backup
-  // TODO: use an arena and heap-allocate these?
   offset_bits_csum_scratch: [Bitlen; FULL_BATCH_N],
   offset_bits_scratch: [Bitlen; FULL_BATCH_N],
   lowers_scratch: [L; FULL_BATCH_N],
@@ -267,6 +266,7 @@ impl<L: Latent> LatentPageDecompressor<L> {
 // Because the size of LatentPageDecompressor is enormous (largely due to
 // scratch buffers), it makes more sense to allocate them on the heap. We only
 // need to derefernce them once per batch, which is plenty infrequent.
+// TODO: consider an arena for these?
 type BoxedLatentPageDecompressor<L> = Box<LatentPageDecompressor<L>>;
 
 define_latent_enum!(

--- a/pco/src/latent_page_decompressor.rs
+++ b/pco/src/latent_page_decompressor.rs
@@ -65,80 +65,7 @@ pub struct LatentPageDecompressor<L: Latent> {
   state: State<L>,
 }
 
-// Because the size of LatentPageDecompressor is enormous (largely due to
-// scratch buffers), it makes more sense to allocate them on the heap. We only
-// need to derefernce them once per batch, which is plenty infrequent.
-pub type BoxedLatentPageDecompressor<L> = Box<LatentPageDecompressor<L>>;
-
-define_latent_enum!(
-  #[derive()]
-  pub DynLatentPageDecompressor(BoxedLatentPageDecompressor)
-);
-
 impl<L: Latent> LatentPageDecompressor<L> {
-  pub fn new(
-    ans_size_log: Bitlen,
-    bins: &[Bin<L>],
-    delta_encoding: DeltaEncoding,
-    ans_final_state_idxs: [AnsState; ANS_INTERLEAVING],
-    stored_delta_state: Vec<L>,
-  ) -> PcoResult<BoxedLatentPageDecompressor<L>> {
-    let u64s_per_offset = read_write_uint::calc_max_u64s(bins::max_offset_bits(bins));
-    let infos = bins
-      .iter()
-      .map(BinDecompressionInfo::new)
-      .collect::<Vec<_>>();
-    let weights = bins::weights(bins);
-    let ans_spec = Spec::from_weights(ans_size_log, weights)?;
-    let decoder = ans::Decoder::new(&ans_spec);
-
-    let (working_delta_state, delta_state_pos) = match delta_encoding {
-      DeltaEncoding::None | DeltaEncoding::Consecutive(_) => (stored_delta_state, 0),
-      DeltaEncoding::Lookback(config) => {
-        delta::new_lookback_window_buffer_and_pos(config, &stored_delta_state)
-      }
-    };
-
-    let mut state = State {
-      offset_bits_csum_scratch: [0; FULL_BATCH_N],
-      offset_bits_scratch: [0; FULL_BATCH_N],
-      lowers_scratch: [L::ZERO; FULL_BATCH_N],
-      ans_state_idxs: ans_final_state_idxs,
-      delta_state: working_delta_state,
-      delta_state_pos,
-    };
-
-    let needs_ans = bins.len() != 1;
-    if !needs_ans {
-      // we optimize performance by setting state once and never again
-      let bin = &bins[0];
-      let mut csum = 0;
-      for i in 0..FULL_BATCH_N {
-        state.offset_bits_scratch[i] = bin.offset_bits;
-        state.offset_bits_csum_scratch[i] = csum;
-        state.lowers_scratch[i] = bin.lower;
-        csum += bin.offset_bits;
-      }
-    }
-
-    let maybe_constant_value =
-      if bins::are_trivial(bins) && matches!(delta_encoding, DeltaEncoding::None) {
-        bins.first().map(|bin| bin.lower)
-      } else {
-        None
-      };
-
-    Ok(Box::new(Self {
-      u64s_per_offset,
-      infos,
-      needs_ans,
-      decoder,
-      delta_encoding,
-      maybe_constant_value,
-      state,
-    }))
-  }
-
   // This implementation handles only a full batch, but is faster.
   #[inline(never)]
   unsafe fn decompress_full_ans_symbols(&mut self, reader: &mut BitReader) {
@@ -334,5 +261,81 @@ impl<L: Latent> LatentPageDecompressor<L> {
         }
       }
     }
+  }
+}
+
+// Because the size of LatentPageDecompressor is enormous (largely due to
+// scratch buffers), it makes more sense to allocate them on the heap. We only
+// need to derefernce them once per batch, which is plenty infrequent.
+pub type BoxedLatentPageDecompressor<L> = Box<LatentPageDecompressor<L>>;
+
+define_latent_enum!(
+  #[derive()]
+  pub DynLatentPageDecompressor(BoxedLatentPageDecompressor)
+);
+
+impl DynLatentPageDecompressor {
+  pub fn create<L: Latent>(
+    ans_size_log: Bitlen,
+    bins: &[Bin<L>],
+    delta_encoding: DeltaEncoding,
+    ans_final_state_idxs: [AnsState; ANS_INTERLEAVING],
+    stored_delta_state: Vec<L>,
+  ) -> PcoResult<Self> {
+    let u64s_per_offset = read_write_uint::calc_max_u64s(bins::max_offset_bits(bins));
+    let infos = bins
+      .iter()
+      .map(BinDecompressionInfo::new)
+      .collect::<Vec<_>>();
+    let weights = bins::weights(bins);
+    let ans_spec = Spec::from_weights(ans_size_log, weights)?;
+    let decoder = ans::Decoder::new(&ans_spec);
+
+    let (working_delta_state, delta_state_pos) = match delta_encoding {
+      DeltaEncoding::None | DeltaEncoding::Consecutive(_) => (stored_delta_state, 0),
+      DeltaEncoding::Lookback(config) => {
+        delta::new_lookback_window_buffer_and_pos(config, &stored_delta_state)
+      }
+    };
+
+    let mut state = State {
+      offset_bits_csum_scratch: [0; FULL_BATCH_N],
+      offset_bits_scratch: [0; FULL_BATCH_N],
+      lowers_scratch: [L::ZERO; FULL_BATCH_N],
+      ans_state_idxs: ans_final_state_idxs,
+      delta_state: working_delta_state,
+      delta_state_pos,
+    };
+
+    let needs_ans = bins.len() != 1;
+    if !needs_ans {
+      // we optimize performance by setting state once and never again
+      let bin = &bins[0];
+      let mut csum = 0;
+      for i in 0..FULL_BATCH_N {
+        state.offset_bits_scratch[i] = bin.offset_bits;
+        state.offset_bits_csum_scratch[i] = csum;
+        state.lowers_scratch[i] = bin.lower;
+        csum += bin.offset_bits;
+      }
+    }
+
+    let maybe_constant_value =
+      if bins::are_trivial(bins) && matches!(delta_encoding, DeltaEncoding::None) {
+        bins.first().map(|bin| bin.lower)
+      } else {
+        None
+      };
+
+    let lpd = LatentPageDecompressor {
+      u64s_per_offset,
+      infos,
+      needs_ans,
+      decoder,
+      delta_encoding,
+      maybe_constant_value,
+      state,
+    };
+    Ok(Self::new(Box::new(lpd)).unwrap())
   }
 }

--- a/pco/src/latent_page_decompressor.rs
+++ b/pco/src/latent_page_decompressor.rs
@@ -267,7 +267,7 @@ impl<L: Latent> LatentPageDecompressor<L> {
 // Because the size of LatentPageDecompressor is enormous (largely due to
 // scratch buffers), it makes more sense to allocate them on the heap. We only
 // need to derefernce them once per batch, which is plenty infrequent.
-pub type BoxedLatentPageDecompressor<L> = Box<LatentPageDecompressor<L>>;
+type BoxedLatentPageDecompressor<L> = Box<LatentPageDecompressor<L>>;
 
 define_latent_enum!(
   #[derive()]

--- a/pco/src/tests/stack_sizes.rs
+++ b/pco/src/tests/stack_sizes.rs
@@ -1,6 +1,8 @@
 use crate::latent_batch_dissector::LatentBatchDissector;
 use crate::latent_chunk_compressor::LatentChunkCompressor;
-use crate::latent_page_decompressor::LatentPageDecompressor;
+use crate::latent_page_decompressor::{
+  BoxedLatentPageDecompressor, DynLatentPageDecompressor, LatentPageDecompressor,
+};
 use crate::metadata::PerLatentVar;
 use crate::wrapped::{ChunkCompressor, ChunkDecompressor, PageDecompressor};
 use std::mem;
@@ -28,11 +30,15 @@ fn test_stack_sizes() {
     4248
   );
   assert_eq!(
-    mem::size_of::<PerLatentVar<LatentPageDecompressor<u64>>>(),
-    12744
+    mem::size_of::<DynLatentPageDecompressor>(),
+    16
+  );
+  assert_eq!(
+    mem::size_of::<PerLatentVar<DynLatentPageDecompressor>>(),
+    48
   );
   assert_eq!(
     mem::size_of::<PageDecompressor<u64, &[u8]>>(),
-    12952
+    256
   );
 }

--- a/pco/src/tests/stack_sizes.rs
+++ b/pco/src/tests/stack_sizes.rs
@@ -1,8 +1,6 @@
 use crate::latent_batch_dissector::LatentBatchDissector;
 use crate::latent_chunk_compressor::LatentChunkCompressor;
-use crate::latent_page_decompressor::{
-  BoxedLatentPageDecompressor, DynLatentPageDecompressor, LatentPageDecompressor,
-};
+use crate::latent_page_decompressor::{DynLatentPageDecompressor, LatentPageDecompressor};
 use crate::metadata::PerLatentVar;
 use crate::wrapped::{ChunkCompressor, ChunkDecompressor, PageDecompressor};
 use std::mem;

--- a/pco/src/wrapped/page_decompressor.rs
+++ b/pco/src/wrapped/page_decompressor.rs
@@ -33,7 +33,6 @@ struct PageDecompressorInner<R: BetterBufRead> {
   // mutable
   reader_builder: BitReaderBuilder<R>,
   n_processed: usize,
-  // TODO make these heap allocated
   latent_decompressors: PerLatentVar<DynLatentPageDecompressor>,
   delta_scratch: Option<LatentScratch>,
   secondary_scratch: Option<LatentScratch>,

--- a/pco/src/wrapped/page_decompressor.rs
+++ b/pco/src/wrapped/page_decompressor.rs
@@ -9,7 +9,7 @@ use crate::bit_reader::BitReaderBuilder;
 use crate::constants::{FULL_BATCH_N, PAGE_PADDING};
 use crate::data_types::Number;
 use crate::errors::{PcoError, PcoResult};
-use crate::latent_page_decompressor::{DynLatentPageDecompressor, LatentPageDecompressor};
+use crate::latent_page_decompressor::DynLatentPageDecompressor;
 use crate::macros::match_latent_enum;
 use crate::metadata::page::PageMeta;
 use crate::metadata::per_latent_var::{PerLatentVar, PerLatentVarBuilder};
@@ -97,15 +97,13 @@ fn make_latent_decompressors(
           )));
         }
 
-        let lpd = LatentPageDecompressor::new(
+        DynLatentPageDecompressor::create(
           chunk_latent_var_meta.ans_size_log,
           bins,
           var_delta_encoding,
           page_latent_var_meta.ans_final_state_idxs,
           delta_state,
-        )?;
-
-        DynLatentPageDecompressor::new(lpd).unwrap()
+        )?
       }
     );
 

--- a/pco/src/wrapped/page_decompressor.rs
+++ b/pco/src/wrapped/page_decompressor.rs
@@ -7,10 +7,10 @@ use better_io::BetterBufRead;
 use crate::bit_reader;
 use crate::bit_reader::BitReaderBuilder;
 use crate::constants::{FULL_BATCH_N, PAGE_PADDING};
-use crate::data_types::{Latent, Number};
+use crate::data_types::Number;
 use crate::errors::{PcoError, PcoResult};
-use crate::latent_page_decompressor::LatentPageDecompressor;
-use crate::macros::{define_latent_enum, match_latent_enum};
+use crate::latent_page_decompressor::{DynLatentPageDecompressor, LatentPageDecompressor};
+use crate::macros::match_latent_enum;
 use crate::metadata::page::PageMeta;
 use crate::metadata::per_latent_var::{PerLatentVar, PerLatentVarBuilder};
 use crate::metadata::{ChunkMeta, DeltaEncoding, DynBins, DynLatents, Mode};
@@ -23,11 +23,6 @@ struct LatentScratch {
   is_constant: bool,
   dst: DynLatents,
 }
-
-define_latent_enum!(
-  #[derive()]
-  DynLatentPageDecompressor(LatentPageDecompressor)
-);
 
 struct PageDecompressorInner<R: BetterBufRead> {
   // immutable


### PR DESCRIPTION
With `pco bench --limit 100 --iters 10000` I now get 41us instead of 127us on my machine. Without the limit, performance is unaffected within measurement error.

#259 