### PR TITLE
FFI publishing fix

### DIFF
--- a/.cargo/config_for_publishing.toml
+++ b/.cargo/config_for_publishing.toml
@@ -1,0 +1,17 @@
+[build]
+rustflags = [
+  # enable LTO to reduce binary size (empirically by ~20%)
+  "-C", "lto=true",
+  "-C", "embed-bitcode=true",
+  "-Zdylib-lto"
+]
+
+# for x64 we have a more specific config to enable the good instruction sets
+[target.'cfg(target_arch = "x86_64")']
+rustflags = [
+  "-C", "target-feature=+bmi1,+bmi2,+avx2",
+  "-C", "lto=true",
+  "-C", "embed-bitcode=true",
+  "-Zdylib-lto"
+]
+

--- a/.github/workflows/java_publish.yml
+++ b/.github/workflows/java_publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cargo Config
-        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Set Rust version
         run: rustup override set nightly
       # it seems that rust targets don't work out of the box on linux,
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cargo Config
-        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Set Rust version
         run: rustup override set nightly
       - name: Add rustup target
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cargo Config
-        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Set Rust version
         run: rustup override set nightly
       - name: Add rustup target

--- a/.github/workflows/java_publish.yml
+++ b/.github/workflows/java_publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cargo Config
-        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Set Rust version
         run: rustup override set nightly
       # it seems that rust targets don't work out of the box on linux,
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cargo Config
-        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Set Rust version
         run: rustup override set nightly
       - name: Add rustup target
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cargo Config
-        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv -Force .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Set Rust version
         run: rustup override set nightly
       - name: Add rustup target

--- a/.github/workflows/java_publish.yml
+++ b/.github/workflows/java_publish.yml
@@ -7,8 +7,6 @@ on:
 
 env:
   GROUP_ID: io/github/pcodec
-  # enable LTO to reduce binary size (empirically by ~20%)
-  RUSTFLAGS: "-C lto=true -C embed-bitcode=true -Zdylib-lto"
 
 jobs:
   linux:
@@ -24,6 +22,8 @@ jobs:
     if: contains(github.event.release.name, 'Java')
     steps:
       - uses: actions/checkout@v4
+      - name: Cargo Config
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Set Rust version
         run: rustup override set nightly
       # it seems that rust targets don't work out of the box on linux,
@@ -51,6 +51,8 @@ jobs:
     if: contains(github.event.release.name, 'Java')
     steps:
       - uses: actions/checkout@v4
+      - name: Cargo Config
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Set Rust version
         run: rustup override set nightly
       - name: Add rustup target
@@ -74,6 +76,8 @@ jobs:
     if: contains(github.event.release.name, 'Java')
     steps:
       - uses: actions/checkout@v4
+      - name: Cargo Config
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Set Rust version
         run: rustup override set nightly
       - name: Add rustup target

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Cargo Config
-        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -52,7 +52,7 @@ jobs:
           python-version: 3.x
           architecture: ${{ matrix.target }}
       - name: Cargo Config
-        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -78,7 +78,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Cargo Config
-        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -24,8 +24,6 @@ jobs:
         target: [ x86_64, x86, aarch64, armv7 ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set Rust version
-        run: rustup override set nightly
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -36,6 +34,7 @@ jobs:
           args: --release --out dist --interpreter 3.9 3.10 3.11 3.12 3.13 --manifest-path pco_python/Cargo.toml
           sccache: 'true'
           manylinux: auto
+          rust-toolchain: nightly
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -50,8 +49,6 @@ jobs:
         target: [ x64 ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set Rust version
-        run: rustup override set nightly
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -62,6 +59,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter 3.9 3.10 3.11 3.12 3.13 --manifest-path pco_python/Cargo.toml
           sccache: 'true'
+          rust-toolchain: nightly
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -76,8 +74,6 @@ jobs:
         target: [ x86_64, aarch64 ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set Rust version
-        run: rustup override set nightly
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -87,6 +83,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter 3.9 3.10 3.11 3.12 3.13 --manifest-path pco_python/Cargo.toml
           sccache: 'true'
+          rust-toolchain: nightly
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -10,10 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # enable LTO to reduce binary size (empirically by ~20%)
-  RUSTFLAGS: "-C lto=true -C embed-bitcode=true -Zdylib-lto"
-
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -27,6 +23,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Cargo Config
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -53,6 +51,8 @@ jobs:
         with:
           python-version: 3.x
           architecture: ${{ matrix.target }}
+      - name: Cargo Config
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -77,6 +77,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Cargo Config
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Cargo Config
-        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -52,7 +52,7 @@ jobs:
           python-version: 3.x
           architecture: ${{ matrix.target }}
       - name: Cargo Config
-        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv -Force .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -78,7 +78,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Cargo Config
-        run: mv -f .cargo/config_for_publishing.toml .cargo/config.toml
+        run: mv .cargo/config_for_publishing.toml .cargo/config.toml
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/pco_java/pom.xml
+++ b/pco_java/pom.xml
@@ -5,6 +5,7 @@
   <version>0.1.1</version>
 
   <packaging>jar</packaging>
+  <name>${project.groupId}:${project.artifactId}</name>
   <description>Good compression for numerical sequences</description>
   <url>https://github.com/pcodec/pcodec</url>
   <licenses>


### PR DESCRIPTION
* specify rust toolchain for python
* specify project name for java
* use a cargo config instead of both cargo config and rustflags (which might not work?)