### PR TITLE
Fix standalone decompression bug in FFI libs when no n_hint is present

### DIFF
--- a/pco/src/standalone/decompressor.rs
+++ b/pco/src/standalone/decompressor.rs
@@ -165,6 +165,15 @@ impl FileDecompressor {
     };
     Ok(MaybeChunkDecompressor::Some(res))
   }
+
+  pub fn simple_decompress<T: Number>(&self, mut src: &[u8]) -> PcoResult<Vec<T>> {
+    let mut res = Vec::with_capacity(self.n_hint());
+    while let MaybeChunkDecompressor::Some(mut chunk_decompressor) = self.chunk_decompressor(src)? {
+      chunk_decompressor.decompress_remaining_extend(&mut res)?;
+      src = chunk_decompressor.into_src();
+    }
+    Ok(res)
+  }
 }
 
 /// Holds metadata about a chunk and supports decompression.

--- a/pco/src/standalone/decompressor.rs
+++ b/pco/src/standalone/decompressor.rs
@@ -166,6 +166,17 @@ impl FileDecompressor {
     Ok(MaybeChunkDecompressor::Some(res))
   }
 
+  /// Takes in compressed bytes (after the header, at the start of the chunks)
+  /// and returns a vector of numbers.
+  ///
+  /// Will return an error if there are any compatibility, corruption,
+  /// or insufficient data issues.
+  ///
+  /// This function exists (in addition to the [standalone
+  /// functions][crate::standalone]) because the user may want to peek at the
+  /// dtype, allowing them to know which type `<T>` to use here. There is no
+  /// analagous file compressor method because the user always knows the dtype
+  /// during compression.
   pub fn simple_decompress<T: Number>(&self, mut src: &[u8]) -> PcoResult<Vec<T>> {
     let mut res = Vec::with_capacity(self.n_hint());
     while let MaybeChunkDecompressor::Some(mut chunk_decompressor) = self.chunk_decompressor(src)? {

--- a/pco/src/standalone/simple.rs
+++ b/pco/src/standalone/simple.rs
@@ -157,16 +157,8 @@ pub fn simpler_compress<T: Number>(nums: &[T], compression_level: usize) -> PcoR
 /// Will return an error if there are any compatibility, corruption,
 /// or insufficient data issues.
 pub fn simple_decompress<T: Number>(src: &[u8]) -> PcoResult<Vec<T>> {
-  let (file_decompressor, mut src) = FileDecompressor::new(src)?;
-
-  let mut res = Vec::with_capacity(file_decompressor.n_hint());
-  while let MaybeChunkDecompressor::Some(mut chunk_decompressor) =
-    file_decompressor.chunk_decompressor(src)?
-  {
-    chunk_decompressor.decompress_remaining_extend(&mut res)?;
-    src = chunk_decompressor.into_src();
-  }
-  Ok(res)
+  let (file_decompressor, src) = FileDecompressor::new(src)?;
+  file_decompressor.simple_decompress(src)
 }
 
 #[cfg(test)]

--- a/pco_java/src/main/rust/src/lib.rs
+++ b/pco_java/src/main/rust/src/lib.rs
@@ -78,6 +78,7 @@ fn decompress_chunks<T: Number + JavaConversions>(
   {
     let initial_len = res.len(); // probably always zero to start, since we just created res
     let remaining = chunk_decompressor.n();
+    res.reserve(remaining);
     unsafe {
       res.set_len(initial_len + remaining);
     }

--- a/pco_java/src/main/rust/src/lib.rs
+++ b/pco_java/src/main/rust/src/lib.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::uninit_vec)]
+#![deny(clippy::unused_unit)]
+#![deny(dead_code)]
 
 mod config;
 mod num_array;
@@ -12,7 +14,7 @@ use jni::sys::*;
 use jni::JNIEnv;
 use pco::data_types::{Number, NumberType};
 use pco::match_number_enum;
-use pco::standalone::{FileDecompressor, MaybeChunkDecompressor};
+use pco::standalone::FileDecompressor;
 
 fn handle_result(env: &mut JNIEnv, result: Result<jobject>) -> jobject {
   // We need a function that creates a fake instance of the return type, due
@@ -68,25 +70,11 @@ fn simple_compress_inner(
 
 fn decompress_chunks<T: Number + JavaConversions>(
   env: &mut JNIEnv,
-  mut src: &[u8],
+  src: &[u8],
   file_decompressor: FileDecompressor,
 ) -> Result<jobject> {
-  let n_hint = file_decompressor.n_hint();
-  let mut res: Vec<T> = Vec::with_capacity(n_hint);
-  while let MaybeChunkDecompressor::Some(mut chunk_decompressor) =
-    file_decompressor.chunk_decompressor::<T, &[u8]>(src)?
-  {
-    let initial_len = res.len(); // probably always zero to start, since we just created res
-    let remaining = chunk_decompressor.n();
-    res.reserve(remaining);
-    unsafe {
-      res.set_len(initial_len + remaining);
-    }
-    let progress = chunk_decompressor.decompress(&mut res[initial_len..])?;
-    assert!(progress.finished);
-    src = chunk_decompressor.into_src();
-  }
-  let num_array = num_array::to_java(env, &res)?;
+  let nums = file_decompressor.simple_decompress::<T>(src)?;
+  let num_array = num_array::to_java(env, &nums)?;
   let optional = env.call_static_method(
     "Ljava/util/Optional;",
     "of",
@@ -119,7 +107,7 @@ fn simple_decompress_inner(env: &mut JNIEnv, src: jbyteArray) -> Result<jobject>
       match_number_enum!(
           number_type,
           NumberType<T> => {
-              decompress_chunks::<T>(env, rest, file_decompressor)
+            decompress_chunks::<T>(env, rest, file_decompressor)
           }
       )
     }

--- a/pco_python/src/lib.rs
+++ b/pco_python/src/lib.rs
@@ -1,3 +1,7 @@
+#![allow(clippy::uninit_vec)]
+#![deny(clippy::unused_unit)]
+#![deny(dead_code)]
+
 use crate::config::{PyChunkConfig, PyDeltaSpec, PyModeSpec, PyPagingSpec};
 use crate::progress::PyProgress;
 use pyo3::prelude::*;

--- a/pco_python/src/standalone.rs
+++ b/pco_python/src/standalone.rs
@@ -9,40 +9,11 @@ use pyo3::types::{PyBytes, PyModule, PyNone};
 use pyo3::{pyfunction, wrap_pyfunction, Bound, PyObject, PyResult, Python};
 
 use pco::data_types::{Number, NumberType};
-use pco::standalone::{FileDecompressor, MaybeChunkDecompressor};
+use pco::standalone::FileDecompressor;
 use pco::{match_number_enum, standalone, ChunkConfig};
 
 use crate::utils::pco_err_to_py;
 use crate::{utils, PyChunkConfig, PyProgress};
-
-fn decompress_chunks<'py, T: Number + Element>(
-  py: Python<'py>,
-  mut src: &[u8],
-  file_decompressor: FileDecompressor,
-) -> PyResult<Bound<'py, PyArray1<T>>> {
-  let res = py
-    .allow_threads(|| {
-      let n_hint = file_decompressor.n_hint();
-      let mut res: Vec<T> = Vec::with_capacity(n_hint);
-      while let MaybeChunkDecompressor::Some(mut chunk_decompressor) =
-        file_decompressor.chunk_decompressor::<T, &[u8]>(src)?
-      {
-        let initial_len = res.len(); // probably always zero to start, since we just created res
-        let remaining = chunk_decompressor.n();
-        res.reserve(remaining);
-        unsafe {
-          res.set_len(initial_len + remaining);
-        }
-        let progress = chunk_decompressor.decompress(&mut res[initial_len..])?;
-        assert!(progress.finished);
-        src = chunk_decompressor.into_src();
-      }
-      Ok(res)
-    })
-    .map_err(pco_err_to_py)?;
-  let py_array = res.into_pyarray(py);
-  Ok(py_array)
-}
 
 fn simple_compress_generic<'py, T: Number + Element>(
   py: Python<'py>,
@@ -155,7 +126,12 @@ pub fn register(m: &Bound<PyModule>) -> PyResult<()> {
         match_number_enum!(
           number_type,
           NumberType<T> => {
-            Ok(decompress_chunks::<T>(py, src, file_decompressor)?.to_object(py))
+            let res = py
+              .allow_threads(|| file_decompressor.simple_decompress::<T>(src))
+              .map_err(pco_err_to_py)?
+              .into_pyarray(py)
+              .to_object(py);
+            Ok(res)
           }
         )
       }

--- a/pco_python/src/standalone.rs
+++ b/pco_python/src/standalone.rs
@@ -29,6 +29,7 @@ fn decompress_chunks<'py, T: Number + Element>(
       {
         let initial_len = res.len(); // probably always zero to start, since we just created res
         let remaining = chunk_decompressor.n();
+        res.reserve(remaining);
         unsafe {
           res.set_len(initial_len + remaining);
         }

--- a/pco_python/test/test_standalone.py
+++ b/pco_python/test/test_standalone.py
@@ -7,6 +7,7 @@ from pcodec import (
     PagingSpec,
     standalone,
 )
+from pathlib import Path
 
 np.random.seed(12345)
 all_lengths = (
@@ -150,3 +151,11 @@ def test_compression_float_mode_spec_options(mode_spec):
 
     # check that the decompressed data is correct
     np.testing.assert_array_equal(data, out)
+
+
+def test_decompress_without_n_hint():
+    # old files didn't have n_hint
+    with open(Path(__file__).parent / "../../pco/assets/v0_0_0_classic.pco", "rb") as f:
+        compressed = f.read()
+
+    assert len(standalone.simple_decompress(compressed)) == 2000


### PR DESCRIPTION
Shared decompression logic with the main crate so that it's harder to mess up.

This bug would only appear in standalone and when running on ancient data or data written by the low-level APIs without an n_hint.

The problem was that we only set the dst vector's capacity according to `n_hint`, which is only a hint and not always present, but kept increasing its length and writing to the end, which could cause a segfault:
```rust
  let mut res: Vec<T> = Vec::with_capacity(n_hint);  // reasonable start
  while let MaybeChunkDecompressor::Some(mut chunk_decompressor) = ... {
    let initial_len = res.len();
    let remaining = chunk_decompressor.n();
    unsafe {
      res.set_len(initial_len + remaining); // DANGER
    }
    let progress = chunk_decompressor.decompress(&mut res[initial_len..])?;  // DANGER
 ```