### PR TITLE
Smaller `Node` struct and replaced while-loop

### DIFF
--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -3,11 +3,11 @@ use crate::ans::{AnsState, Symbol};
 use crate::constants::Bitlen;
 
 #[derive(Clone, Debug)]
-#[repr(align(16))]
+#[repr(align(8))]
 pub struct Node {
-  pub symbol: Symbol,
-  pub next_state_idx_base: AnsState,
-  pub bits_to_read: Bitlen,
+  pub symbol: u16,
+  pub next_state_idx_base: u16,
+  pub bits_to_read: u16,
 }
 
 #[derive(Clone, Debug)]
@@ -29,8 +29,8 @@ impl Decoder {
         bits_to_read += 1;
       }
       nodes.push(Node {
-        symbol,
-        next_state_idx_base: next_state_base - table_size as AnsState,
+        symbol: symbol as u16,
+        next_state_idx_base: (next_state_base - table_size as AnsState) as u16,
         bits_to_read,
       });
       symbol_x_s[symbol as usize] += 1;

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -1,11 +1,11 @@
 use crate::ans::spec::Spec;
-use crate::ans::{AnsState, CompactAnsState, CompactSymbol};
+use crate::ans::{AnsState, CompactAnsState, Symbol};
 use crate::constants::CompactBitlen;
 
 #[derive(Clone, Debug)]
 #[repr(align(8))]
 pub struct Node {
-  pub symbol: CompactSymbol,
+  pub symbol: Symbol,
   pub next_state_idx_base: CompactAnsState,
   pub bits_to_read: CompactBitlen,
 }
@@ -26,7 +26,7 @@ impl Decoder {
       let bits_to_read = next_state_base.leading_zeros() - (table_size as AnsState).leading_zeros();
       let next_state_base = next_state_base << bits_to_read;
       nodes.push(Node {
-        symbol: symbol as CompactSymbol,
+        symbol,
         next_state_idx_base: (next_state_base - table_size as AnsState) as CompactAnsState,
         bits_to_read: bits_to_read as CompactBitlen,
       });

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -1,15 +1,15 @@
 use crate::ans::spec::Spec;
-use crate::ans::{AnsState, CompactAnsState, CompactSymbol};
-use crate::constants::Bitlen;
+use crate::ans::{AnsState, CompactAnsState, Symbol};
+use crate::constants::CompactBitlen;
 
 // Using smallar types for AnsState and Bitlen to reduce the memory footprint
 // of Node. This improves performance, likely due to fewer cache misses.
 #[derive(Clone, Debug)]
 #[repr(align(8))]
 pub struct Node {
-  pub symbol: CompactSymbol,
+  pub symbol: Symbol,
   pub next_state_idx_base: CompactAnsState,
-  pub bits_to_read: Bitlen,
+  pub bits_to_read: CompactBitlen,
 }
 
 #[derive(Clone, Debug)]
@@ -28,9 +28,9 @@ impl Decoder {
       let bits_to_read = next_state_base.leading_zeros() - (table_size as AnsState).leading_zeros();
       let next_state_base = next_state_base << bits_to_read;
       nodes.push(Node {
-        symbol: symbol as CompactSymbol,
+        symbol,
         next_state_idx_base: (next_state_base - table_size as AnsState) as CompactAnsState,
-        bits_to_read,
+        bits_to_read: bits_to_read as CompactBitlen,
       });
       symbol_x_s[symbol as usize] += 1;
     }

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -22,16 +22,13 @@ impl Decoder {
     // x_s from Jarek Duda's paper
     let mut symbol_x_s = spec.symbol_weights.clone();
     for &symbol in &spec.state_symbols {
-      let mut next_state_base = symbol_x_s[symbol as usize] as AnsState;
-      let mut bits_to_read = 0;
-      while next_state_base < table_size as AnsState {
-        next_state_base *= 2;
-        bits_to_read += 1;
-      }
+      let next_state_base = symbol_x_s[symbol as usize] as AnsState;
+      let bits_to_read = next_state_base.leading_zeros() - (table_size as AnsState).leading_zeros();
+      let next_state_base = next_state_base << bits_to_read;
       nodes.push(Node {
         symbol: symbol as CompactSymbol,
         next_state_idx_base: (next_state_base - table_size as AnsState) as CompactAnsState,
-        bits_to_read,
+        bits_to_read: bits_to_read as CompactBitlen,
       });
       symbol_x_s[symbol as usize] += 1;
     }

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -2,6 +2,8 @@ use crate::ans::spec::Spec;
 use crate::ans::{AnsState, CompactAnsState, Symbol};
 use crate::constants::CompactBitlen;
 
+// Using smallar types for AnsState and Bitlen to reduce the memory footprint
+// of Node. This improves performance, likely due to fewer cache misses.
 #[derive(Clone, Debug)]
 #[repr(align(8))]
 pub struct Node {

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -1,13 +1,13 @@
 use crate::ans::spec::Spec;
-use crate::ans::{AnsState, Symbol};
-use crate::constants::Bitlen;
+use crate::ans::{AnsState, CompactAnsState, CompactSymbol};
+use crate::constants::CompactBitlen;
 
 #[derive(Clone, Debug)]
 #[repr(align(8))]
 pub struct Node {
-  pub symbol: u16,
-  pub next_state_idx_base: u16,
-  pub bits_to_read: u16,
+  pub symbol: CompactSymbol,
+  pub next_state_idx_base: CompactAnsState,
+  pub bits_to_read: CompactBitlen,
 }
 
 #[derive(Clone, Debug)]
@@ -29,8 +29,8 @@ impl Decoder {
         bits_to_read += 1;
       }
       nodes.push(Node {
-        symbol: symbol as u16,
-        next_state_idx_base: (next_state_base - table_size as AnsState) as u16,
+        symbol: symbol as CompactSymbol,
+        next_state_idx_base: (next_state_base - table_size as AnsState) as CompactAnsState,
         bits_to_read,
       });
       symbol_x_s[symbol as usize] += 1;

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -1,6 +1,5 @@
 use crate::ans::spec::Spec;
 use crate::ans::{AnsState, CompactAnsState, CompactSymbol};
-use crate::constants::CompactBitlen;
 use crate::data_types::Latent;
 use crate::metadata::Bin;
 
@@ -9,11 +8,12 @@ use crate::metadata::Bin;
 #[derive(Clone, Debug)]
 #[repr(align(8))]
 pub struct Node {
+  pub offset_bits_bits_to_read: u32,
   pub symbol: CompactSymbol,
   pub next_state_idx_base: CompactAnsState,
   // pub ans_part: CompactAnsState,
-  pub offset_bits: CompactBitlen,
-  pub bits_to_read: CompactBitlen,
+  // pub offset_bits: CompactBitlen,
+  // pub bits_to_read: CompactBitlen,
 }
 
 #[derive(Clone, Debug)]
@@ -31,12 +31,18 @@ impl Decoder {
       let next_state_base = symbol_x_s[symbol as usize] as AnsState;
       let bits_to_read = next_state_base.leading_zeros() - (table_size as AnsState).leading_zeros();
       let next_state_base = next_state_base << bits_to_read;
+      let offset_bits = if bins.len() > symbol as usize {
+        bins[symbol as usize].offset_bits
+      } else {
+        0
+      };
       nodes.push(Node {
         symbol: symbol as CompactSymbol,
         next_state_idx_base: (next_state_base - table_size as AnsState) as CompactAnsState,
-        offset_bits: bins[symbol as usize].offset_bits as CompactBitlen,
-        bits_to_read: bits_to_read as CompactBitlen,
+        // offset_bits: bins[symbol as usize].offset_bits as CompactBitlen,
+        // bits_to_read: bits_to_read as CompactBitlen,
         // ans_part: ((1 << bits_to_read) - 1) as CompactAnsState,
+        offset_bits_bits_to_read: (offset_bits << 16) | bits_to_read,
       });
       symbol_x_s[symbol as usize] += 1;
     }

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -1,15 +1,15 @@
 use crate::ans::spec::Spec;
-use crate::ans::{AnsState, CompactAnsState, Symbol};
-use crate::constants::CompactBitlen;
+use crate::ans::{AnsState, CompactAnsState, CompactSymbol};
+use crate::constants::Bitlen;
 
 // Using smallar types for AnsState and Bitlen to reduce the memory footprint
 // of Node. This improves performance, likely due to fewer cache misses.
 #[derive(Clone, Debug)]
 #[repr(align(8))]
 pub struct Node {
-  pub symbol: Symbol,
+  pub symbol: CompactSymbol,
   pub next_state_idx_base: CompactAnsState,
-  pub bits_to_read: CompactBitlen,
+  pub bits_to_read: Bitlen,
 }
 
 #[derive(Clone, Debug)]
@@ -28,9 +28,9 @@ impl Decoder {
       let bits_to_read = next_state_base.leading_zeros() - (table_size as AnsState).leading_zeros();
       let next_state_base = next_state_base << bits_to_read;
       nodes.push(Node {
-        symbol,
+        symbol: symbol as CompactSymbol,
         next_state_idx_base: (next_state_base - table_size as AnsState) as CompactAnsState,
-        bits_to_read: bits_to_read as CompactBitlen,
+        bits_to_read,
       });
       symbol_x_s[symbol as usize] += 1;
     }

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -1,14 +1,18 @@
 use crate::ans::spec::Spec;
-use crate::ans::{AnsState, CompactAnsState, Symbol};
+use crate::ans::{AnsState, CompactAnsState, CompactSymbol};
 use crate::constants::CompactBitlen;
+use crate::data_types::Latent;
+use crate::metadata::Bin;
 
 // Using smallar types for AnsState and Bitlen to reduce the memory footprint
 // of Node. This improves performance, likely due to fewer cache misses.
 #[derive(Clone, Debug)]
 #[repr(align(8))]
 pub struct Node {
-  pub symbol: Symbol,
+  pub symbol: CompactSymbol,
   pub next_state_idx_base: CompactAnsState,
+  // pub ans_part: CompactAnsState,
+  pub offset_bits: CompactBitlen,
   pub bits_to_read: CompactBitlen,
 }
 
@@ -18,7 +22,7 @@ pub struct Decoder {
 }
 
 impl Decoder {
-  pub fn new(spec: &Spec) -> Self {
+  pub fn new<L: Latent>(spec: &Spec, bins: &[Bin<L>]) -> Self {
     let table_size = spec.table_size();
     let mut nodes = Vec::with_capacity(table_size);
     // x_s from Jarek Duda's paper
@@ -28,9 +32,11 @@ impl Decoder {
       let bits_to_read = next_state_base.leading_zeros() - (table_size as AnsState).leading_zeros();
       let next_state_base = next_state_base << bits_to_read;
       nodes.push(Node {
-        symbol,
+        symbol: symbol as CompactSymbol,
         next_state_idx_base: (next_state_base - table_size as AnsState) as CompactAnsState,
+        offset_bits: bins[symbol as usize].offset_bits as CompactBitlen,
         bits_to_read: bits_to_read as CompactBitlen,
+        // ans_part: ((1 << bits_to_read) - 1) as CompactAnsState,
       });
       symbol_x_s[symbol as usize] += 1;
     }

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -9,9 +9,11 @@ mod spec;
 
 // must be u16 or larger
 // should not be exposed in public API
+pub(crate) type CompactAnsState = u16;
 pub(crate) type AnsState = u32;
 // must be u16 or larger
 // should not be exposed in public API
+pub(crate) type CompactSymbol = u16;
 pub(crate) type Symbol = u32;
 
 #[cfg(test)]
@@ -22,7 +24,7 @@ mod tests {
   use crate::bit_writer::BitWriter;
   use crate::bits;
   use crate::constants::Bitlen;
-use crate::errors::PcoResult;
+  use crate::errors::PcoResult;
 
   fn assert_recovers(spec: &Spec, symbols: Vec<Symbol>, expected_byte_len: usize) -> PcoResult<()> {
     // ENCODE
@@ -57,8 +59,8 @@ use crate::errors::PcoResult;
     for _ in 0..symbols.len() {
       let node = &decoder.nodes[state_idx as usize];
       decoded.push(node.symbol as Symbol);
-      state_idx =
-        node.next_state_idx_base as AnsState + unsafe { reader.read_uint::<AnsState>(node.bits_to_read as Bitlen) };
+      state_idx = node.next_state_idx_base as AnsState
+        + unsafe { reader.read_uint::<AnsState>(node.bits_to_read as Bitlen) };
     }
 
     assert_eq!(decoded, symbols);

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -57,7 +57,7 @@ mod tests {
     let mut state_idx = final_state - table_size;
     for _ in 0..symbols.len() {
       let node = &decoder.nodes[state_idx as usize];
-      decoded.push(node.symbol as Symbol);
+      decoded.push(node.symbol);
       state_idx = node.next_state_idx_base as AnsState
         + unsafe { reader.read_uint::<AnsState>(node.bits_to_read as Bitlen) };
     }

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -13,7 +13,6 @@ pub(crate) type CompactAnsState = u16;
 pub(crate) type AnsState = u32;
 // must be u16 or larger
 // should not be exposed in public API
-pub(crate) type CompactSymbol = u16;
 pub(crate) type Symbol = u32;
 
 #[cfg(test)]

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -21,7 +21,8 @@ mod tests {
   use crate::bit_reader::BitReader;
   use crate::bit_writer::BitWriter;
   use crate::bits;
-  use crate::errors::PcoResult;
+  use crate::constants::Bitlen;
+use crate::errors::PcoResult;
 
   fn assert_recovers(spec: &Spec, symbols: Vec<Symbol>, expected_byte_len: usize) -> PcoResult<()> {
     // ENCODE
@@ -55,9 +56,9 @@ mod tests {
     let mut state_idx = final_state - table_size;
     for _ in 0..symbols.len() {
       let node = &decoder.nodes[state_idx as usize];
-      decoded.push(node.symbol);
+      decoded.push(node.symbol as Symbol);
       state_idx =
-        node.next_state_idx_base + unsafe { reader.read_uint::<AnsState>(node.bits_to_read) };
+        node.next_state_idx_base as AnsState + unsafe { reader.read_uint::<AnsState>(node.bits_to_read as Bitlen) };
     }
 
     assert_eq!(decoded, symbols);

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -13,7 +13,6 @@ pub(crate) type CompactAnsState = u16;
 pub(crate) type AnsState = u32;
 // must be u16 or larger
 // should not be exposed in public API
-pub(crate) type CompactSymbol = u32;
 pub(crate) type Symbol = u32;
 
 #[cfg(test)]

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -58,9 +58,9 @@ mod tests {
     let mut state_idx = final_state - table_size;
     for _ in 0..symbols.len() {
       let node = &decoder.nodes[state_idx as usize];
-      decoded.push(node.symbol as Symbol);
+      decoded.push(node.symbol);
       state_idx = node.next_state_idx_base as AnsState
-        + unsafe { reader.read_uint::<AnsState>(node.bits_to_read) };
+        + unsafe { reader.read_uint::<AnsState>(node.bits_to_read as Bitlen) };
     }
 
     assert_eq!(decoded, symbols);

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -13,6 +13,7 @@ pub(crate) type CompactAnsState = u16;
 pub(crate) type AnsState = u32;
 // must be u16 or larger
 // should not be exposed in public API
+pub(crate) type CompactSymbol = u16;
 pub(crate) type Symbol = u32;
 
 #[cfg(test)]

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -58,9 +58,9 @@ mod tests {
     let mut state_idx = final_state - table_size;
     for _ in 0..symbols.len() {
       let node = &decoder.nodes[state_idx as usize];
-      decoded.push(node.symbol);
+      decoded.push(node.symbol as Symbol);
       state_idx = node.next_state_idx_base as AnsState
-        + unsafe { reader.read_uint::<AnsState>(node.bits_to_read as Bitlen) };
+        + unsafe { reader.read_uint::<AnsState>(node.bits_to_read) };
     }
 
     assert_eq!(decoded, symbols);

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -13,7 +13,7 @@ pub(crate) type CompactAnsState = u16;
 pub(crate) type AnsState = u32;
 // must be u16 or larger
 // should not be exposed in public API
-pub(crate) type CompactSymbol = u16;
+pub(crate) type CompactSymbol = u32;
 pub(crate) type Symbol = u32;
 
 #[cfg(test)]

--- a/pco/src/constants.rs
+++ b/pco/src/constants.rs
@@ -2,7 +2,7 @@
 // u32 is performant because it aligns with other things and doesn't require
 // masking
 // exposed in public API
-pub(crate) type CompactBitlen = u8;
+// pub(crate) type CompactBitlen = u8;
 pub(crate) type Bitlen = u32;
 // must be u32 or larger
 // exposed in public API

--- a/pco/src/constants.rs
+++ b/pco/src/constants.rs
@@ -2,7 +2,6 @@
 // u32 is performant because it aligns with other things and doesn't require
 // masking
 // exposed in public API
-pub(crate) type CompactBitlen = u16;
 pub(crate) type Bitlen = u32;
 // must be u32 or larger
 // exposed in public API

--- a/pco/src/constants.rs
+++ b/pco/src/constants.rs
@@ -2,7 +2,7 @@
 // u32 is performant because it aligns with other things and doesn't require
 // masking
 // exposed in public API
-pub(crate) type CompactBitlen = u16;
+pub(crate) type CompactBitlen = u8;
 pub(crate) type Bitlen = u32;
 // must be u32 or larger
 // exposed in public API

--- a/pco/src/constants.rs
+++ b/pco/src/constants.rs
@@ -2,6 +2,7 @@
 // u32 is performant because it aligns with other things and doesn't require
 // masking
 // exposed in public API
+pub(crate) type CompactBitlen = u16;
 pub(crate) type Bitlen = u32;
 // must be u32 or larger
 // exposed in public API

--- a/pco/src/latent_page_decompressor.rs
+++ b/pco/src/latent_page_decompressor.rs
@@ -130,8 +130,8 @@ impl<L: Latent> LatentPageDecompressor<L> {
       let ans_val = (packed >> bits_past_byte) as AnsState & ((1 << node.bits_to_read) - 1);
       let info = &self.infos[node.symbol as usize];
       self.state.set_scratch(i, offset_bit_idx, info);
-      bits_past_byte += node.bits_to_read;
-      offset_bit_idx += info.offset_bits;
+      bits_past_byte += node.bits_to_read as Bitlen;
+      offset_bit_idx += info.offset_bits as Bitlen;
       state_idxs[j] = node.next_state_idx_base as AnsState + ans_val;
     }
 

--- a/pco/src/latent_page_decompressor.rs
+++ b/pco/src/latent_page_decompressor.rs
@@ -130,8 +130,8 @@ impl<L: Latent> LatentPageDecompressor<L> {
       let ans_val = (packed >> bits_past_byte) as AnsState & ((1 << node.bits_to_read) - 1);
       let info = &self.infos[node.symbol as usize];
       self.state.set_scratch(i, offset_bit_idx, info);
-      bits_past_byte += node.bits_to_read as Bitlen;
-      offset_bit_idx += info.offset_bits as Bitlen;
+      bits_past_byte += node.bits_to_read;
+      offset_bit_idx += info.offset_bits;
       state_idxs[j] = node.next_state_idx_base as AnsState + ans_val;
     }
 

--- a/pco/src/latent_page_decompressor.rs
+++ b/pco/src/latent_page_decompressor.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::ans::{AnsState, Spec};
 use crate::bit_reader::BitReader;
-use crate::constants::{Bitlen, CompactBitlen, DeltaLookback, ANS_INTERLEAVING, FULL_BATCH_N};
+use crate::constants::{Bitlen, DeltaLookback, ANS_INTERLEAVING, FULL_BATCH_N};
 use crate::data_types::Latent;
 use crate::errors::{PcoError, PcoResult};
 use crate::macros::define_latent_enum;
@@ -14,14 +14,14 @@ use crate::{ans, bit_reader, delta, read_write_uint};
 #[derive(Clone, Copy, Debug)]
 pub struct BinDecompressionInfo<L: Latent> {
   pub lower: L,
-  pub offset_bits: CompactBitlen,
+  pub offset_bits: Bitlen,
 }
 
 impl<L: Latent> BinDecompressionInfo<L> {
   fn new(bin: &Bin<L>) -> Self {
     Self {
       lower: bin.lower,
-      offset_bits: bin.offset_bits as CompactBitlen,
+      offset_bits: bin.offset_bits,
     }
   }
 }
@@ -43,7 +43,7 @@ impl<L: Latent> State<L> {
   fn set_scratch(&mut self, i: usize, offset_bit_idx: Bitlen, info: &BinDecompressionInfo<L>) {
     unsafe {
       *self.offset_bits_csum_scratch.get_unchecked_mut(i) = offset_bit_idx;
-      *self.offset_bits_scratch.get_unchecked_mut(i) = info.offset_bits as Bitlen;
+      *self.offset_bits_scratch.get_unchecked_mut(i) = info.offset_bits;
       *self.lowers_scratch.get_unchecked_mut(i) = info.lower;
     };
   }
@@ -96,8 +96,8 @@ impl<L: Latent> LatentPageDecompressor<L> {
           let ans_val = (packed >> bits_past_byte) as AnsState & ((1 << node.bits_to_read) - 1);
           let info = unsafe { infos.get_unchecked(node.symbol as usize) };
           self.state.set_scratch(i, offset_bit_idx, info);
-          bits_past_byte += node.bits_to_read as Bitlen;
-          offset_bit_idx += info.offset_bits as Bitlen;
+          bits_past_byte += node.bits_to_read;
+          offset_bit_idx += info.offset_bits;
           $state_idx = node.next_state_idx_base as AnsState + ans_val;
         };
       }

--- a/pco/src/latent_page_decompressor.rs
+++ b/pco/src/latent_page_decompressor.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::ans::{AnsState, Spec};
 use crate::bit_reader::BitReader;
-use crate::constants::{Bitlen, DeltaLookback, ANS_INTERLEAVING, FULL_BATCH_N};
+use crate::constants::{Bitlen, CompactBitlen, DeltaLookback, ANS_INTERLEAVING, FULL_BATCH_N};
 use crate::data_types::Latent;
 use crate::errors::{PcoError, PcoResult};
 use crate::macros::define_latent_enum;
@@ -14,14 +14,14 @@ use crate::{ans, bit_reader, delta, read_write_uint};
 #[derive(Clone, Copy, Debug)]
 pub struct BinDecompressionInfo<L: Latent> {
   pub lower: L,
-  pub offset_bits: u16,
+  pub offset_bits: CompactBitlen,
 }
 
 impl<L: Latent> BinDecompressionInfo<L> {
   fn new(bin: &Bin<L>) -> Self {
     Self {
       lower: bin.lower,
-      offset_bits: bin.offset_bits as u16,
+      offset_bits: bin.offset_bits as CompactBitlen,
     }
   }
 }

--- a/pco/src/latent_page_decompressor.rs
+++ b/pco/src/latent_page_decompressor.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::ans::{AnsState, Spec};
 use crate::bit_reader::BitReader;
-use crate::constants::{Bitlen, DeltaLookback, ANS_INTERLEAVING, FULL_BATCH_N};
+use crate::constants::{Bitlen, CompactBitlen, DeltaLookback, ANS_INTERLEAVING, FULL_BATCH_N};
 use crate::data_types::Latent;
 use crate::errors::{PcoError, PcoResult};
 use crate::macros::define_latent_enum;
@@ -14,14 +14,14 @@ use crate::{ans, bit_reader, delta, read_write_uint};
 #[derive(Clone, Copy, Debug)]
 pub struct BinDecompressionInfo<L: Latent> {
   pub lower: L,
-  pub offset_bits: Bitlen,
+  pub offset_bits: CompactBitlen,
 }
 
 impl<L: Latent> BinDecompressionInfo<L> {
   fn new(bin: &Bin<L>) -> Self {
     Self {
       lower: bin.lower,
-      offset_bits: bin.offset_bits,
+      offset_bits: bin.offset_bits as CompactBitlen,
     }
   }
 }
@@ -43,7 +43,7 @@ impl<L: Latent> State<L> {
   fn set_scratch(&mut self, i: usize, offset_bit_idx: Bitlen, info: &BinDecompressionInfo<L>) {
     unsafe {
       *self.offset_bits_csum_scratch.get_unchecked_mut(i) = offset_bit_idx;
-      *self.offset_bits_scratch.get_unchecked_mut(i) = info.offset_bits;
+      *self.offset_bits_scratch.get_unchecked_mut(i) = info.offset_bits as Bitlen;
       *self.lowers_scratch.get_unchecked_mut(i) = info.lower;
     };
   }
@@ -96,8 +96,8 @@ impl<L: Latent> LatentPageDecompressor<L> {
           let ans_val = (packed >> bits_past_byte) as AnsState & ((1 << node.bits_to_read) - 1);
           let info = unsafe { infos.get_unchecked(node.symbol as usize) };
           self.state.set_scratch(i, offset_bit_idx, info);
-          bits_past_byte += node.bits_to_read;
-          offset_bit_idx += info.offset_bits;
+          bits_past_byte += node.bits_to_read as Bitlen;
+          offset_bit_idx += info.offset_bits as Bitlen;
           $state_idx = node.next_state_idx_base as AnsState + ans_val;
         };
       }


### PR DESCRIPTION
The reduced size of `Node` appears to improve decode performance by 3-4% on some systems. This is likely due to fewer cache misses.

Replacing the while-loop in `Decoder::new` shouldn't really affect performance, but thought it was nicer to calculate the values.