### PR TITLE
I think this shell command needs quotes?

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,7 +37,7 @@ for harder, underspecified problems.
 
 From a venv with `maturin` installed, and from `pco_python/`, run
 `maturin develop` to recompile and install the python package into your venv.
-Then you can run `pytest --doctest-glob=*.md`.
+Then you can run `pytest --doctest-glob='*.md'`.
 
 ## Java
 


### PR DESCRIPTION
As written, I think the shell will attempt to expand the glob pattern and so `pytest` won't see the glob pattern, which is not what we want.