### PR TITLE
fix cargo build on macos;

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,15 +1,8 @@
 [target.'cfg(target_arch = "x86_64")']
 rustflags = ["-C", "target-feature=+bmi1,+bmi2,+avx2"]
 
-[target.x86_64-apple-darwin]
+[target.'cfg(target_os = "macos")']
 rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
-
-[target.aarch64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
-

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,15 @@
 [target.'cfg(target_arch = "x86_64")']
 rustflags = ["-C", "target-feature=+bmi1,+bmi2,+avx2"]
+
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+


### PR DESCRIPTION
Hi, there is an error when I try to build on MacOS with M1 chip.

error: linking with `cc` failed: exit status: 1

According to the documentation of PYO3, I fix the problem successfully.
https://pyo3.rs/v0.20.2/building_and_distribution#macos

