### PR TITLE
FCBench CLI tweaks

### DIFF
--- a/pco_cli/src/bench/codecs/blosc.rs
+++ b/pco_cli/src/bench/codecs/blosc.rs
@@ -5,6 +5,10 @@ use crate::bench::codecs::CodecInternal;
 use crate::dtypes::PcoNumber;
 use clap::Parser;
 
+// gotta divide each compress/decompress call into chunks of byte size less than
+// this or else blosc can't handle them
+const CHUNK_SIZE: usize = 1 << 30;
+
 #[derive(Clone, Debug, Parser)]
 pub struct BloscConfig {
   #[arg(long, default_value = "1048576")]
@@ -70,49 +74,70 @@ impl CodecInternal for BloscConfig {
 
   fn compress<T: PcoNumber>(&self, nums: &[T]) -> Vec<u8> {
     let n_bytes = mem::size_of_val(nums);
-    let mut dst = Vec::with_capacity(n_bytes + blosc2_src::BLOSC2_MAX_OVERHEAD as usize);
+    let n_chunks = n_bytes.div_ceil(CHUNK_SIZE);
+    let type_size = mem::size_of::<T>();
+    let mut dst =
+      Vec::with_capacity(4 + n_bytes + n_chunks * blosc2_src::BLOSC2_MAX_OVERHEAD as usize);
+    dst.extend((n_chunks as u32).to_le_bytes());
+    let ctx = unsafe { self.create_ctx(type_size as i32) };
+    for chunk in nums.chunks(CHUNK_SIZE / type_size) {
+      let chunk_n_bytes = mem::size_of_val(chunk);
+      let dst_available = (dst.capacity() - dst.len()).min(i32::MAX as usize) as i32;
+      unsafe {
+        let src = chunk.as_ptr() as *const c_void;
+        let compressed_size = blosc2_src::blosc2_compress_ctx(
+          ctx,
+          src,
+          chunk_n_bytes as i32,
+          dst.as_mut_ptr().add(dst.len()) as *mut c_void,
+          dst_available,
+        );
+        dst.set_len(dst.len() + compressed_size as usize);
+      }
+    }
+
     unsafe {
-      let src = nums.as_ptr() as *const c_void;
-      let ctx = self.create_ctx(mem::size_of::<T>() as i32);
-      let compressed_size = blosc2_src::blosc2_compress_ctx(
-        ctx,
-        src,
-        n_bytes as i32,
-        dst.as_mut_ptr() as *mut c_void,
-        dst.capacity() as i32,
-      );
-      dst.set_len(compressed_size as usize);
       blosc2_src::blosc2_free_ctx(ctx);
     }
     dst
   }
 
-  fn decompress<T: PcoNumber>(&self, compressed: &[u8]) -> Vec<T> {
-    let mut uncompressed_size = 0;
-    let mut compressed_size = 0;
-    let mut block_size = 0;
-    unsafe {
-      let src = compressed.as_ptr() as *const c_void;
-      let ctx = self.create_dctx();
-      blosc2_src::blosc2_cbuffer_sizes(
-        src,
-        &mut uncompressed_size as *mut i32,
-        &mut compressed_size as *mut i32,
-        &mut block_size as *mut i32,
-      );
-      let n = uncompressed_size as usize / mem::size_of::<T>();
-      let mut res = Vec::with_capacity(n);
-      let dst = res.as_mut_ptr() as *mut c_void;
-      blosc2_src::blosc2_decompress_ctx(
-        ctx,
-        src,
-        compressed.len() as i32,
-        dst,
-        uncompressed_size,
-      );
-      blosc2_src::blosc2_free_ctx(ctx);
-      res.set_len(n);
-      res
+  fn decompress<T: PcoNumber>(&self, mut compressed: &[u8]) -> Vec<T> {
+    let n_chunks = u32::from_le_bytes(compressed[0..4].try_into().unwrap()) as usize;
+    compressed = &compressed[4..];
+    let mut res = Vec::<T>::new();
+
+    let ctx = unsafe { self.create_dctx() };
+    for _ in 0..n_chunks {
+      let mut uncompressed_size = 0;
+      let mut compressed_size = 0;
+      let mut block_size = 0;
+      unsafe {
+        let src = compressed.as_ptr() as *const c_void;
+        blosc2_src::blosc2_cbuffer_sizes(
+          src,
+          &mut uncompressed_size as *mut i32,
+          &mut compressed_size as *mut i32,
+          &mut block_size as *mut i32,
+        );
+        let chunk_n = uncompressed_size as usize / mem::size_of::<T>();
+        res.reserve(chunk_n);
+        let dst = res.as_mut_ptr().add(res.len()) as *mut c_void;
+        blosc2_src::blosc2_decompress_ctx(
+          ctx,
+          src,
+          compressed.len().min(i32::MAX as usize) as i32,
+          dst,
+          uncompressed_size,
+        );
+        res.set_len(res.len() + chunk_n);
+        compressed = &compressed[compressed_size as usize..];
+      }
     }
+
+    unsafe {
+      blosc2_src::blosc2_free_ctx(ctx);
+    }
+    res
   }
 }

--- a/pco_cli/src/bench/mod.rs
+++ b/pco_cli/src/bench/mod.rs
@@ -395,7 +395,7 @@ fn print_stats(disaggregated_stats: Vec<PrintStat>, opt: &BenchOpt) -> Result<()
       PrintStat::new("<sum>".to_string(), codec, bench_stat)
     })
     .collect::<Vec<_>>();
-  let stats = vec![disaggregated_stats.clone(), aggregated_stats.clone()].concat();
+  let stats = [disaggregated_stats.clone(), aggregated_stats.clone()].concat();
   let mut table_builder = Table::builder(stats);
   let unit_columns_to_keep: Vec<usize> = match opt.units {
     // we expect these to be sorted


### PR DESCRIPTION
* For binary input format, support dtype at end of filename instead of start
* Wrap Blosc to support byte size > 2^31
* Fixed a lint