### PR TITLE
Read 32-bit offsets

### DIFF
--- a/pco/src/data_types/mod.rs
+++ b/pco/src/data_types/mod.rs
@@ -119,6 +119,10 @@ pub trait Latent:
 
   /// Converts a `usize` into this type. Panics if the conversion is
   /// impossible.
+  fn from_u32(x: u32) -> Self;
+
+  /// Converts a `usize` into this type. Panics if the conversion is
+  /// impossible.
   fn from_u64(x: u64) -> Self;
 
   fn leading_zeros(self) -> Bitlen;

--- a/pco/src/data_types/unsigneds.rs
+++ b/pco/src/data_types/unsigneds.rs
@@ -53,6 +53,11 @@ macro_rules! impl_latent {
       const BITS: Bitlen = Self::BITS as Bitlen;
 
       #[inline]
+      fn from_u32(x: u32) -> Self {
+        x as Self
+      }
+
+      #[inline]
       fn from_u64(x: u64) -> Self {
         x as Self
       }

--- a/pco/src/read_write_uint.rs
+++ b/pco/src/read_write_uint.rs
@@ -5,6 +5,22 @@ use crate::constants::Bitlen;
 use crate::data_types::Latent;
 
 // this applies to reading and also works for byte-aligned precisions
+pub const fn calc_max_bytes(precision: Bitlen) -> usize {
+  // See bit_reader::read_uint_at for an explanation of these thresholds.
+  if precision == 0 {
+    0
+  } else if precision <= 25 {
+    4
+  } else if precision <= 57 {
+    8
+  } else if precision <= 113 {
+    16
+  } else {
+    24
+  }
+}
+
+// this applies to reading and also works for byte-aligned precisions
 pub const fn calc_max_u64s(precision: Bitlen) -> usize {
   // See bit_reader::read_uint_at for an explanation of these thresholds.
   if precision == 0 {
@@ -48,7 +64,9 @@ pub trait ReadWriteUint:
   const ONE: Self;
   const BITS: Bitlen;
   const MAX_U64S: usize = calc_max_u64s(Self::BITS);
+  const MAX_BYTES: usize = calc_max_bytes(Self::BITS);
 
+  fn from_u32(x: u32) -> Self;
   fn from_u64(x: u64) -> Self;
   fn to_u64(self) -> u64;
 }
@@ -56,6 +74,11 @@ pub trait ReadWriteUint:
 impl ReadWriteUint for usize {
   const ONE: Self = 1;
   const BITS: Bitlen = usize::BITS;
+
+  #[inline]
+  fn from_u32(x: u32) -> Self {
+    x as Self
+  }
 
   #[inline]
   fn from_u64(x: u64) -> Self {
@@ -71,6 +94,11 @@ impl ReadWriteUint for usize {
 impl<L: Latent> ReadWriteUint for L {
   const ONE: Self = <Self as Latent>::ONE;
   const BITS: Bitlen = <Self as Latent>::BITS;
+
+  #[inline]
+  fn from_u32(x: u32) -> Self {
+    <Self as Latent>::from_u32(x)
+  }
 
   #[inline]
   fn from_u64(x: u64) -> Self {


### PR DESCRIPTION
Support for reading data 32-bits at a time. This allows faster decompression of shorter latent types due to better SIMD bandwidth usage. On my PC I see around 5-15% faster decompression on 16-bit types.

I've been playing around a bit and this is the solution with the fewest changes that seemed decent. That said, I'm not a big fan of the matches on numbers (of bytes or u64s). Seems like an `enum` would be better suited.

We could also extend this change to be used for `write_uint` as well, but I'm not sure if it'll actually provide a performance gain. If we do that, I definitely think we should change from `usize` to `enum`.

One thing to consider is that avoiding `u64` intermediate representation likely only improves performance for non-`u64` latents. So even if `bytes_per_offset < 25` for a 64-bit type, because the output latents are 64 bits wide, it's not clear that reading 32 bit bites will improve throughput. Changes in the compiled SIMD could have the opposite effect. We should benchmark this.

This change does not appear to fix missing vectorization of `decompress_offsets` for `u16` latents on `aarch64`.