### PR TITLE
Added paginated pco format to benchmarks

### DIFF
--- a/pco/src/chunk_config.rs
+++ b/pco/src/chunk_config.rs
@@ -169,7 +169,7 @@ impl Default for PagingSpec {
 }
 
 impl PagingSpec {
-  pub(crate) fn n_per_page(&self, n: usize) -> PcoResult<Vec<usize>> {
+  pub fn n_per_page(&self, n: usize) -> PcoResult<Vec<usize>> {
     let n_per_page = match self {
       // You might think it would be beneficial to do either of these:
       // * greedily fill pages since compressed chunk size seems like a concave

--- a/pco/src/wrapped/page_decompressor.rs
+++ b/pco/src/wrapped/page_decompressor.rs
@@ -116,10 +116,8 @@ impl<R: BetterBufRead> PageDecompressorInner<R> {
     bit_reader::ensure_buf_read_capacity(&mut src, PERFORMANT_BUF_READ_CAPACITY);
     let mut reader_builder = BitReaderBuilder::new(src, PAGE_PADDING, 0);
 
-    // println!("A {}", PAGE_PADDING);
     let page_meta =
       reader_builder.with_reader(|reader| unsafe { PageMeta::read_from(reader, chunk_meta) })?;
-    // println!("B");
 
     let mode = chunk_meta.mode;
     let latent_decompressors = make_latent_decompressors(chunk_meta, &page_meta, n)?;
@@ -127,7 +125,6 @@ impl<R: BetterBufRead> PageDecompressorInner<R> {
     let delta_scratch = make_latent_scratch(latent_decompressors.delta.as_ref());
     let secondary_scratch = make_latent_scratch(latent_decompressors.secondary.as_ref());
 
-    // println!("C");
     // we don't store the whole ChunkMeta because it can get large due to bins
     Ok(Self {
       n,

--- a/pco/src/wrapped/page_decompressor.rs
+++ b/pco/src/wrapped/page_decompressor.rs
@@ -116,8 +116,10 @@ impl<R: BetterBufRead> PageDecompressorInner<R> {
     bit_reader::ensure_buf_read_capacity(&mut src, PERFORMANT_BUF_READ_CAPACITY);
     let mut reader_builder = BitReaderBuilder::new(src, PAGE_PADDING, 0);
 
+    // println!("A {}", PAGE_PADDING);
     let page_meta =
       reader_builder.with_reader(|reader| unsafe { PageMeta::read_from(reader, chunk_meta) })?;
+    // println!("B");
 
     let mode = chunk_meta.mode;
     let latent_decompressors = make_latent_decompressors(chunk_meta, &page_meta, n)?;
@@ -125,6 +127,7 @@ impl<R: BetterBufRead> PageDecompressorInner<R> {
     let delta_scratch = make_latent_scratch(latent_decompressors.delta.as_ref());
     let secondary_scratch = make_latent_scratch(latent_decompressors.secondary.as_ref());
 
+    // println!("C");
     // we don't store the whole ChunkMeta because it can get large due to bins
     Ok(Self {
       n,

--- a/pco_cli/src/bench/codecs/mod.rs
+++ b/pco_cli/src/bench/codecs/mod.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 use crate::bench::codecs::parquet::ParquetConfig;
+use crate::bench::codecs::pcopage::PaginatedPcoConfig;
 use crate::bench::codecs::snappy::SnappyConfig;
 use crate::bench::codecs::zstd::ZstdConfig;
 use crate::bench::IterOpt;
@@ -25,6 +26,7 @@ mod blosc;
 mod brotli;
 mod parquet;
 mod pco;
+mod pcopage;
 #[cfg(feature = "full_bench")]
 mod qco;
 mod snappy;
@@ -252,6 +254,7 @@ impl FromStr for CodecConfig {
       "brotli" => brotli::BrotliConfig::from_kv_args(&clap_kv_args),
       "parquet" => ParquetConfig::from_kv_args(&clap_kv_args),
       "pco" | "pcodec" => ChunkConfigOpt::from_kv_args(&clap_kv_args),
+      "pcopage" => PaginatedPcoConfig::from_kv_args(&clap_kv_args),
       #[cfg(feature = "full_bench")]
       "qco" | "q_compress" => qco::QcoConfig::from_kv_args(&clap_kv_args),
       "snap" | "snappy" => SnappyConfig::from_kv_args(&clap_kv_args),

--- a/pco_cli/src/bench/codecs/pcopage.rs
+++ b/pco_cli/src/bench/codecs/pcopage.rs
@@ -1,0 +1,114 @@
+use clap::Parser;
+use pco::wrapped::{FileCompressor, FileDecompressor};
+use pco::{ChunkConfig, PagingSpec};
+
+use crate::bench::codecs::CodecInternal;
+use crate::dtypes::PcoNumber;
+
+// This is designed to be a dumb format that just tests Pco's pagination
+// capabilities and performance. It isn't super optimized; in particular, it
+// isn't aware of the uncompressed sizes of pages or chunks, so it repeatedly
+// allocates instead of doing so once upfront.
+#[derive(Clone, Debug, Parser)]
+pub struct PaginatedPcoConfig {
+  #[arg(long, default_value_t = pco::DEFAULT_COMPRESSION_LEVEL)]
+  pub level: usize,
+  #[arg(long, default_value_t = pco::DEFAULT_MAX_PAGE_N)]
+  pub chunk_n: usize,
+  #[arg(long, default_value_t = pco::DEFAULT_MAX_PAGE_N)]
+  pub page_n: usize,
+}
+
+impl CodecInternal for PaginatedPcoConfig {
+  fn name(&self) -> &'static str {
+    "pcopage"
+  }
+
+  fn get_confs(&self) -> Vec<(&'static str, String)> {
+    vec![
+      ("level", self.level.to_string()),
+      ("chunk-n", self.chunk_n.to_string()),
+      ("page-n", self.page_n.to_string()),
+    ]
+  }
+
+  fn compress<T: PcoNumber>(&self, nums: &[T]) -> Vec<u8> {
+    let n = nums.len();
+    let chunk_ns = PagingSpec::EqualPagesUpTo(self.chunk_n)
+      .n_per_page(n)
+      .unwrap();
+    let config = ChunkConfig::default()
+      .with_compression_level(self.level)
+      .with_paging_spec(PagingSpec::EqualPagesUpTo(self.page_n));
+
+    let fc = FileCompressor::default();
+    let mut dst = Vec::new();
+    dst.extend((n as u64).to_le_bytes());
+    dst.extend((chunk_ns.len() as u32).to_le_bytes());
+    fc.write_header(&mut dst).unwrap();
+
+    let mut start = 0;
+    for chunk_n in chunk_ns {
+      let end = start + chunk_n;
+
+      let cc = fc
+        .chunk_compressor::<T>(&nums[start..end], &config)
+        .unwrap();
+
+      let n_per_page = cc.n_per_page();
+      let n_pages = n_per_page.len();
+      let additional_size_est = 4
+        + cc.chunk_meta_size_hint()
+        + (0..n_pages)
+          .map(|page_i| 4 + cc.page_size_hint(page_i))
+          .sum::<usize>();
+      dst.reserve(additional_size_est);
+      dst.extend((n_pages as u32).to_le_bytes());
+      cc.write_chunk_meta(&mut dst).unwrap();
+      for page_i in 0..n_pages {
+        let page_n = n_per_page[page_i];
+        dst.extend((page_n as u32).to_le_bytes());
+        cc.write_page(page_i, &mut dst).unwrap();
+      }
+
+      start = end;
+    }
+
+    dst
+  }
+
+  fn decompress<T: PcoNumber>(&self, bytes: &[u8]) -> Vec<T> {
+    let mut src = bytes;
+    let n = u64::from_le_bytes(bytes[0..8].try_into().unwrap()) as usize;
+    src = &src[8..];
+    let n_chunks = u32::from_le_bytes(src[0..4].try_into().unwrap()) as usize;
+    src = &src[4..];
+
+    let mut dst = Vec::with_capacity(n);
+    unsafe {
+      dst.set_len(n);
+    }
+
+    let (fd, rest) = FileDecompressor::new(src).unwrap();
+    src = rest;
+
+    let mut i = 0;
+    for _ in 0..n_chunks {
+      let n_pages = u32::from_le_bytes(src[0..4].try_into().unwrap()) as usize;
+      src = &src[4..];
+      let (cd, rest) = fd.chunk_decompressor(src).unwrap();
+      src = rest;
+
+      for _ in 0..n_pages {
+        let page_n = u32::from_le_bytes(src[0..4].try_into().unwrap()) as usize;
+        src = &src[4..];
+        let mut pd = cd.page_decompressor(src, page_n).unwrap();
+        pd.decompress(&mut dst[i..]).unwrap();
+        i += page_n;
+        src = pd.into_src();
+      }
+    }
+
+    dst
+  }
+}

--- a/pco_cli/src/bench/codecs/pcopage.rs
+++ b/pco_cli/src/bench/codecs/pcopage.rs
@@ -65,8 +65,7 @@ impl CodecInternal for PaginatedPcoConfig {
       dst.reserve(additional_size_est);
       dst.extend((n_pages as u32).to_le_bytes());
       cc.write_chunk_meta(&mut dst).unwrap();
-      for page_i in 0..n_pages {
-        let page_n = n_per_page[page_i];
+      for (page_i, page_n) in n_per_page.into_iter().enumerate() {
         dst.extend((page_n as u32).to_le_bytes());
         cc.write_page(page_i, &mut dst).unwrap();
       }

--- a/pco_cli/src/bench/codecs/pcopage.rs
+++ b/pco_cli/src/bench/codecs/pcopage.rs
@@ -6,9 +6,7 @@ use crate::bench::codecs::CodecInternal;
 use crate::dtypes::PcoNumber;
 
 // This is designed to be a dumb format that just tests Pco's pagination
-// capabilities and performance. It isn't super optimized; in particular, it
-// isn't aware of the uncompressed sizes of pages or chunks, so it repeatedly
-// allocates instead of doing so once upfront.
+// capabilities and performance. It isn't stable.
 #[derive(Clone, Debug, Parser)]
 pub struct PaginatedPcoConfig {
   #[arg(long, default_value_t = pco::DEFAULT_COMPRESSION_LEVEL)]

--- a/pco_cli/src/chunk_config_opt.rs
+++ b/pco_cli/src/chunk_config_opt.rs
@@ -9,9 +9,6 @@ pub struct ChunkConfigOpt {
   /// Compression level.
   #[arg(long, default_value = "8")]
   pub level: usize,
-  // We fully quality `Option` to use a value parser that returns Option<usize>
-  // instead of just usize. See
-  // https://github.com/clap-rs/clap/issues/5536#issuecomment-2179646989
   /// Can be "Auto", "None", "Consecutive@<order>", or "Lookback".
   #[arg(long, default_value = "Auto", value_parser = parse::delta_spec)]
   pub delta: DeltaSpec,


### PR DESCRIPTION
This also exposes the n_per_page function from `PagingSpec`, which seems useful and pretty stable.
Results on the synthetic benchmarks:

```
╭──────────────────────┬──────────────────────┬──────────────┬───────────────┬─────────────────╮
│ dataset              │ codec                │  compress_dt │ decompress_dt │ compressed_size │
├──────────────────────┼──────────────────────┼──────────────┼───────────────┼─────────────────┤
│ <sum>                │ pco                  │ 775.966545ms │  107.237332ms │        65130478 │
│ <sum>                │ pcopage              │ 779.716631ms │   105.45725ms │        65131097 │
│ <sum>                │ pcopage:page-n=10000 │ 791.262913ms │  118.611795ms │        65271329 │
│ <sum>                │ pcopage:page-n=1000  │ 844.302709ms │  227.338416ms │        65996552 │
│ <sum>                │ pcopage:page-n=100   │ 1.783879873s │  1.212524291s │        70990543 │
╰──────────────────────┴──────────────────────┴──────────────┴───────────────┴─────────────────╯
```

So it seems that finer pages introduce a noticeable decompression performance impact as early as 10k, compression around 1k, and file size between 1k to 100. The performance impacts could probably be investigated and ameliorated.