### PR TITLE
Variable sampling proportion

### DIFF
--- a/pco/src/data_types/float.rs
+++ b/pco/src/data_types/float.rs
@@ -89,7 +89,11 @@ fn choose_mode_bids<F: Float>(nums: &[F], chunk_config: &ChunkConfig) -> PcoResu
         split_fn: Box::new(|nums| classic::split_latents(nums)),
       }];
 
-      if let Some(sample) = sampling::choose_mode_sample(nums, filter_sample) {
+      if let Some(sample) = sampling::choose_mode_sample(
+        nums,
+        chunk_config.compression_level,
+        filter_sample,
+      ) {
         bids.extend(float_mult::compute_bid(&sample));
         bids.extend(float_quant::compute_bid(&sample));
       }

--- a/pco/src/data_types/unsigned.rs
+++ b/pco/src/data_types/unsigned.rs
@@ -27,7 +27,7 @@ fn int_mult_bid<T: Number>(base: T::L) -> Bid<T> {
 
 pub fn choose_mode_bids<T: Number>(nums: &[T], config: &ChunkConfig) -> PcoResult<Vec<Bid<T>>> {
   let bids = match config.mode_spec {
-    ModeSpec::Auto => match int_mult::choose_base(nums) {
+    ModeSpec::Auto => match int_mult::choose_base(nums, config.compression_level) {
       // int mult is only bid when it's already known to be worthwhile, so we
       // don't offer classic alongside it
       Some(base) => vec![int_mult_bid(base)],

--- a/pco/src/mode/int_mult.rs
+++ b/pco/src/mode/int_mult.rs
@@ -212,8 +212,10 @@ pub fn choose_candidate_base<L: Latent>(sample: &mut [L]) -> Option<(L, f64)> {
   most_prominent_gcd(&triple_gcds, sample.len() / 3)
 }
 
-pub fn choose_base<T: Number>(nums: &[T]) -> Option<T::L> {
-  let mut sample = sampling::choose_mode_sample(nums, |num| Some(num.to_latent_ordered()))?;
+pub fn choose_base<T: Number>(nums: &[T], compression_level: usize) -> Option<T::L> {
+  let mut sample = sampling::choose_mode_sample(nums, compression_level, |num| {
+    Some(num.to_latent_ordered())
+  })?;
   let (candidate, bits_saved_per_adj) = choose_candidate_base(&mut sample)?;
 
   if sampling::est_bits_saved_per_num(&sample, |x| PrimaryLatentAndSavings {

--- a/pco/src/sampling.rs
+++ b/pco/src/sampling.rs
@@ -8,16 +8,33 @@ use rand_xoshiro::rand_core::{RngCore, SeedableRng};
 use crate::data_types::Latent;
 
 pub const MIN_SAMPLE: usize = 10;
-// 1 in this many nums get put into sample
-const SAMPLE_RATIO: usize = 40;
 // Int mults will be considered infrequent if they occur less than 1/this of
 // the time.
 const CLASSIC_MEMORIZABLE_BINS: f64 = (1 << CLASSIC_MEMORIZABLE_BINS_LOG) as f64;
 const DELTA_TARGET_GROUP_N: usize = 200;
 
-fn calc_sample_n(n: usize) -> Option<usize> {
+fn calc_sample_n(n: usize, compression_level: usize) -> Option<usize> {
+  // Bin selection compute cost is roughly affine up to 8 due to histogram, then
+  // starts to grow faster due to bin optimization, so we increase sample size
+  // in a qualitatively similar fashion.
+  let sample_prop = match compression_level {
+    0 => 0.010,
+    1 => 0.011,
+    2 => 0.013,
+    3 => 0.015,
+    4 => 0.017,
+    5 => 0.019,
+    6 => 0.021,
+    7 => 0.023,
+    8 => 0.025,
+    9 => 0.028,
+    10 => 0.031,
+    11 => 0.035,
+    12 => 0.040,
+    _ => unreachable!("impossible compression level"),
+  };
   if n >= MIN_SAMPLE {
-    Some(MIN_SAMPLE + (n - MIN_SAMPLE) / SAMPLE_RATIO)
+    Some(MIN_SAMPLE + ((n - MIN_SAMPLE) as f64 * sample_prop) as usize)
   } else {
     None
   }
@@ -46,12 +63,15 @@ fn choose_delta_sample_inner(
   )
 }
 
-pub(crate) fn choose_delta_sample(primary_latents: &DynLatents) -> Option<DynLatents> {
+pub(crate) fn choose_delta_sample(
+  primary_latents: &DynLatents,
+  compression_level: usize,
+) -> Option<DynLatents> {
   // We select some large contiguous groups of latents so that delta encodings
   // can both sample from a variety of places in the chunk while minimizing the
   // number of unnatural jumps.
   let n = primary_latents.len();
-  let target_sample_n = calc_sample_n(n)?;
+  let target_sample_n = calc_sample_n(n, compression_level)?;
   Some(choose_delta_sample_inner(
     primary_latents,
     DELTA_TARGET_GROUP_N.min(n),
@@ -72,13 +92,14 @@ fn mark_visited(visited: &mut [u8], idx: usize) {
 #[inline(never)]
 pub fn choose_mode_sample<T, S, Filter: Fn(&T) -> Option<S>>(
   nums: &[T],
+  compression_level: usize,
   filter: Filter,
 ) -> Option<Vec<S>> {
   // We use Floyd's algorithm to draw a sample without replacement or modifying
   // nums. One nice property is that if we take a larger sample, it will begin
   // with the same subset as a smaller sample, keeping noise manageable.
   let n = nums.len();
-  let target_sample_n = calc_sample_n(n)?;
+  let target_sample_n = calc_sample_n(n, compression_level)?;
 
   let mut rng = rand_xoshiro::Xoroshiro128PlusPlus::seed_from_u64(0);
   let mut visited = vec![0_u8; n.div_ceil(8)];
@@ -143,10 +164,18 @@ mod tests {
 
   #[test]
   fn test_sample_n() {
-    assert_eq!(calc_sample_n(9), None);
-    assert_eq!(calc_sample_n(10), Some(10));
-    assert_eq!(calc_sample_n(100), Some(12));
-    assert_eq!(calc_sample_n(1000010), Some(25010));
+    assert_eq!(calc_sample_n(9, 8), None);
+    assert_eq!(calc_sample_n(10, 8), Some(10));
+    assert_eq!(calc_sample_n(100, 8), Some(12));
+    assert_eq!(calc_sample_n(1000010, 8), Some(25010));
+    assert_eq!(calc_sample_n(1000010, 0), Some(10010));
+  }
+
+  #[test]
+  fn test_sample_n_monotonic_in_level() {
+    for i in 1..13 {
+      assert!(calc_sample_n(10000, i).unwrap() >= calc_sample_n(10000, i - 1).unwrap());
+    }
   }
 
   #[test]
@@ -188,7 +217,7 @@ mod tests {
     for i in 0..150 {
       nums.push(-i as f32);
     }
-    let mut sample = choose_mode_sample(&nums, |&num| {
+    let mut sample = choose_mode_sample(&nums, 8, |&num| {
       if num == 0.0 {
         None
       } else {

--- a/pco/src/wrapped/chunk_compressor.rs
+++ b/pco/src/wrapped/chunk_compressor.rs
@@ -309,9 +309,10 @@ fn calculate_compressed_sample_size(
 #[inline(never)]
 fn choose_auto_delta_encoding(
   primary_latents: &DynLatents,
+  compression_level: usize,
   unoptimized_bins_log: Bitlen,
 ) -> PcoResult<DeltaEncoding> {
-  let Some(sample) = sampling::choose_delta_sample(primary_latents) else {
+  let Some(sample) = sampling::choose_delta_sample(primary_latents, compression_level) else {
     return Ok(DeltaEncoding::NoOp);
   };
   let sample_n = sample.len();
@@ -377,7 +378,11 @@ fn choose_delta_encoding(
 ) -> PcoResult<DeltaEncoding> {
   let n = latents.primary.len();
   let delta_encoding = match config.delta_spec {
-    DeltaSpec::Auto => choose_auto_delta_encoding(&latents.primary, unoptimized_bins_log)?,
+    DeltaSpec::Auto => choose_auto_delta_encoding(
+      &latents.primary,
+      config.compression_level,
+      unoptimized_bins_log,
+    )?,
     DeltaSpec::NoOp | DeltaSpec::TryConsecutive(0) | DeltaSpec::TryConv1(0) => DeltaEncoding::NoOp,
     DeltaSpec::TryConsecutive(order) => DeltaEncoding::Consecutive {
       order,


### PR DESCRIPTION
Vary mode + delta encoding sampling proportion based on compression level.

Before and after on air quality:
```
╭───────────────────────┬──────────────┬──────────────┬───────────────┬─────────────────╮
│ dataset               │ codec        │  compress_dt │ decompress_dt │ compressed_size │
├───────────────────────┼──────────────┼──────────────┼───────────────┼─────────────────┤
│ <sum>                 │ pco:level=0  │   28.36371ms │           0ns │        11404934 │
│ <sum>                 │ pco:level=1  │  65.681833ms │           0ns │         9666779 │
│ <sum>                 │ pco:level=2  │     76.095ms │           0ns │         6397748 │
│ <sum>                 │ pco:level=3  │  79.093999ms │           0ns │         5465699 │
│ <sum>                 │ pco:level=4  │  82.821877ms │           0ns │         4850650 │
│ <sum>                 │ pco:level=5  │   84.93975ms │           0ns │         4587817 │
│ <sum>                 │ pco:level=6  │  86.609623ms │           0ns │         4417047 │
│ <sum>                 │ pco:level=7  │  89.335337ms │           0ns │         4331940 │
│ <sum>                 │ pco          │  92.293418ms │           0ns │         4283268 │
│ <sum>                 │ pco:level=9  │  98.300043ms │           0ns │         4260563 │
│ <sum>                 │ pco:level=10 │  115.58225ms │           0ns │         4247247 │
│ <sum>                 │ pco:level=11 │ 174.831752ms │           0ns │         4242106 │
│ <sum>                 │ pco:level=12 │ 389.744209ms │           0ns │         4239594 │

│ <sum>                 │ pco:level=0  │  22.872334ms │           0ns │        11739562 │
│ <sum>                 │ pco:level=1  │  60.635041ms │           0ns │         9530947 │
│ <sum>                 │ pco:level=2  │  71.711249ms │           0ns │         6385321 │
│ <sum>                 │ pco:level=3  │  75.320168ms │           0ns │         5473492 │
│ <sum>                 │ pco:level=4  │  80.412708ms │           0ns │         4850650 │
│ <sum>                 │ pco:level=5  │  82.368502ms │           0ns │         4587817 │
│ <sum>                 │ pco:level=6  │  84.884792ms │           0ns │         4417047 │
│ <sum>                 │ pco:level=7  │  87.802378ms │           0ns │         4331940 │
│ <sum>                 │ pco          │  92.216582ms │           0ns │         4283268 │
│ <sum>                 │ pco:level=9  │  98.726418ms │           0ns │         4260563 │
│ <sum>                 │ pco:level=10 │ 116.751374ms │           0ns │         4247247 │
│ <sum>                 │ pco:level=11 │ 177.360915ms │           0ns │         4242106 │
│ <sum>                 │ pco:level=12 │ 409.607582ms │           0ns │         4239594 │
```

on taxi:
```
│ <sum>                    │ pco:level=0  │  1.410888167s │           0ns │       827277978 │
│ <sum>                    │ pco:level=1  │  2.886891793s │           0ns │       476631094 │
│ <sum>                    │ pco:level=2  │  3.061578248s │           0ns │       403602416 │
│ <sum>                    │ pco:level=3  │  3.344635291s │           0ns │       380002067 │
│ <sum>                    │ pco:level=4  │  3.625144419s │           0ns │       360417404 │
│ <sum>                    │ pco:level=5  │  3.616086333s │           0ns │       348096018 │
│ <sum>                    │ pco:level=6  │  3.795498377s │           0ns │       339889071 │
│ <sum>                    │ pco:level=7  │  3.994650917s │           0ns │       335453985 │
│ <sum>                    │ pco          │  4.250994916s │           0ns │       333011652 │
│ <sum>                    │ pco:level=9  │     4.766195s │           0ns │       331801214 │
│ <sum>                    │ pco:level=10 │  6.208075085s │           0ns │       330164983 │
│ <sum>                    │ pco:level=11 │  10.68217317s │           0ns │       329201174 │
│ <sum>                    │ pco:level=12 │ 22.188773167s │           0ns │       328886750 │

│ <sum>                    │ pco:level=0  │  1.251711709s │           0ns │       812790242 │
│ <sum>                    │ pco:level=1  │    2.7504345s │           0ns │       478963634 │
│ <sum>                    │ pco:level=2  │  2.967136376s │           0ns │       403357434 │
│ <sum>                    │ pco:level=3  │  3.289035623s │           0ns │       380074102 │
│ <sum>                    │ pco:level=4  │  3.580677667s │           0ns │       360988925 │
│ <sum>                    │ pco:level=5  │  3.633091126s │           0ns │       347965120 │
│ <sum>                    │ pco:level=6  │  3.838974625s │           0ns │       339897599 │
│ <sum>                    │ pco:level=7  │  4.075615084s │           0ns │       335453985 │
│ <sum>                    │ pco          │  4.364148167s │           0ns │       333011652 │
│ <sum>                    │ pco:level=9  │  4.942238333s │           0ns │       332071529 │
│ <sum>                    │ pco:level=10 │  6.519003041s │           0ns │       330164513 │
│ <sum>                    │ pco:level=11 │ 11.244500003s │           0ns │       329201174 │
│ <sum>                    │ pco:level=12 │ 24.358375625s │           0ns │       328886750 │
```