### PR TITLE
Faster lookback

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(target_arch = "x86_64")']
-rustflags = ["-C", "target-feature=+bmi1,+bmi2,+avx2"]
+rustflags = ["-C", "target-feature=+bmi1,+bmi2,+lzcnt,+avx2"]
 
 [target.'cfg(target_os = "macos")']
 rustflags = [

--- a/.cargo/config_for_publishing.toml
+++ b/.cargo/config_for_publishing.toml
@@ -9,7 +9,7 @@ rustflags = [
 # for x64 we have a more specific config to enable the good instruction sets
 [target.'cfg(target_arch = "x86_64")']
 rustflags = [
-  "-C", "target-feature=+bmi1,+bmi2,+avx2",
+  "-C", "target-feature=+bmi1,+bmi2,+lzcnt,+avx2",
   "-C", "lto=true",
   "-C", "embed-bitcode=true",
   "-Zdylib-lto"

--- a/pco/README.md
+++ b/pco/README.md
@@ -32,7 +32,7 @@ fn main() -> PcoResult<()> {
 
 # Compilation Notes
 
-**For best performance on x86_64, compile with `bmi1`, `bmi2`, and `avx2`**.
+**For best performance on x86_64, compile with `bmi1`, `bmi2`, `lzcnt`, and `avx2`**.
 This improves compression speed slightly and decompression speed substantially!
 Almost all hardware nowadays supports these instruction sets.
 To make sure you're using these, you can:
@@ -40,9 +40,9 @@ To make sure you're using these, you can:
 * Add the following to your `~/.cargo/config.toml`:
 ```toml
 [target.'cfg(target_arch = "x86_64")']
-rustflags = ["-C", "target-feature=+bmi1,+bmi2,+avx2"]
+rustflags = ["-C", "target-feature=+bmi1,+bmi2,+lzcnt,+avx2"]
 ```
-* OR compile with `RUSTFLAGS="-C target-feature=+bmi1,+bmi2,+avx2" cargo build --release ...`
+* OR compile with `RUSTFLAGS="-C target-feature=+bmi1,+bmi2,+lzcnt,+avx2" cargo build --release ...`
 
 Note that setting `target-cpu=native` does not always have the same effect,
 since LLVM compiles for the lowest common denominator of instructions for a

--- a/pco/build.rs
+++ b/pco/build.rs
@@ -14,6 +14,9 @@ fn main() {
     if !cfg!(target_feature = "bmi2") {
       missing_instructions.push("bmi2");
     }
+    if !cfg!(target_feature = "lzcnt") {
+      missing_instructions.push("lzcnt");
+    }
     if !cfg!(target_feature = "avx2") {
       missing_instructions.push("avx2");
     }

--- a/pco/src/delta/lookback.rs
+++ b/pco/src/delta/lookback.rs
@@ -11,6 +11,8 @@ use crate::FULL_BATCH_N;
 // * repeating: try the most recent lookbacks we actually used
 // * hash: look up similar values by hash
 const PROPOSED_LOOKBACKS: usize = 16;
+// `find_best_lookback` packs a proposal's index into the low 4 bits of its score.
+const _: () = assert!(PROPOSED_LOOKBACKS <= 16);
 const BRUTE_LOOKBACKS: usize = 6;
 const REPEATING_LOOKBACKS: usize = 4;
 // To help locate similar latents for lookback encoding, we hash each latent at
@@ -24,7 +26,7 @@ fn hash_lookup(
   i: usize,
   hash_table_n: usize,
   window_n: usize,
-  idx_hash_table: &mut [usize],
+  idx_hash_table: &mut [u32],
   proposed_lookbacks: &mut [usize; PROPOSED_LOOKBACKS],
 ) {
   let hash_mask = hash_table_n - 1;
@@ -46,7 +48,8 @@ fn hash_lookup(
       // SAFETY: `h = hash_fn(...) & hash_mask < hash_table_n`, and
       // `offset` is a multiple of `hash_table_n` with at most
       // `COARSENESSES.len() - 1` increments, so `offset + h < idx_hash_table.len()`.
-      let lookback_to_last_instance = unsafe { i - *idx_hash_table.get_unchecked(offset + h) };
+      let lookback_to_last_instance =
+        unsafe { i - *idx_hash_table.get_unchecked(offset + h) as usize };
       proposed_lookbacks[proposal_idx] = if lookback_to_last_instance <= window_n {
         lookback_to_last_instance
       } else {
@@ -57,7 +60,7 @@ fn hash_lookup(
     let h = hashes[1];
     // SAFETY: same bounds argument as the read above.
     unsafe {
-      *idx_hash_table.get_unchecked_mut(offset + h) = i;
+      *idx_hash_table.get_unchecked_mut(offset + h) = i as u32;
     }
     offset += hash_table_n;
   }
@@ -69,32 +72,33 @@ fn find_best_lookback<L: Latent>(
   i: usize,
   latents: &[L],
   proposed_lookbacks: &[usize; PROPOSED_LOOKBACKS],
-  lookback_counts: &mut [u32],
+  lookback_goodnesses: &[u8],
 ) -> usize {
-  let mut best_goodness = 0;
-  let mut best_lookback: usize = 0;
-  for &lookback in proposed_lookbacks {
+  // Each candidate's score is packed as `goodness << 4 | (last index - index)`
+  // so that a single max reduction picks the highest goodness, breaking ties
+  // toward the earliest proposal. Scoring every candidate up front and
+  // reducing afterwards keeps the loop free of a serial compare chain.
+  let mut scores = [0_u32; PROPOSED_LOOKBACKS];
+  for (idx, &lookback) in proposed_lookbacks.iter().enumerate() {
     // SAFETY: each `lookback` comes from `proposed_lookbacks`, whose entries
     // are initialised to `(k+1).min(state_n) >= 1` and subsequently updated
-    // only to values in `[1, window_n]`.  `window_n <= lookback_counts.len()`,
-    // so `lookback - 1 < lookback_counts.len()`.  `i >= state_n >= lookback`,
+    // only to values in `[1, window_n]`.  `window_n <= lookback_goodnesses.len()`,
+    // so `lookback - 1 < lookback_goodnesses.len()`.  `i >= state_n >= lookback`,
     // so `i - lookback` doesn't underflow and stays in `[0, latents.len())`.
-    let (lookback_count, other) = unsafe {
+    let (lookback_goodness, other) = unsafe {
       (
-        *lookback_counts.get_unchecked(lookback - 1),
+        *lookback_goodnesses.get_unchecked(lookback - 1),
         *latents.get_unchecked(i - lookback),
       )
     };
-    let lookback_goodness = Bitlen::BITS - lookback_count.leading_zeros();
     let delta = L::min(l.wrapping_sub(other), other.wrapping_sub(l));
-    let delta_goodness = delta.leading_zeros();
-    let goodness = lookback_goodness + delta_goodness;
-    if goodness > best_goodness {
-      best_goodness = goodness;
-      best_lookback = lookback;
-    }
+    let goodness = lookback_goodness as Bitlen + delta.leading_zeros();
+    scores[idx] = (goodness << 4) | (PROPOSED_LOOKBACKS - 1 - idx) as u32;
   }
-  best_lookback
+
+  let best_score = scores.iter().copied().max().unwrap();
+  let best_idx = PROPOSED_LOOKBACKS - 1 - (best_score & 0xf) as usize;
+  proposed_lookbacks[best_idx]
 }
 
 #[inline(never)]
@@ -116,10 +120,14 @@ pub fn choose_lookbacks<L: Latent>(
     "we do not support tiny windows during compression"
   );
 
-  let mut lookback_counts = vec![1_u32; window_n.min(latents.len())];
+  let n_lookbacks = window_n.min(latents.len());
+  let mut lookback_counts = vec![1_u32; n_lookbacks];
+  // `lookback_goodnesses[j]` is always the bit width of `lookback_counts[j]`.
+  // Keeping it precomputed and narrow makes the hot inner loop much cheaper.
+  let mut lookback_goodnesses = vec![1_u8; n_lookbacks];
   let mut lookbacks = Vec::with_capacity(latents.len() - state_n);
   let uninit_lookbacks = lookbacks.spare_capacity_mut();
-  let mut idx_hash_table = vec![0_usize; COARSENESSES.len() * hash_table_n];
+  let mut idx_hash_table = vec![0_u32; COARSENESSES.len() * hash_table_n];
   let mut proposed_lookbacks = array::from_fn::<_, PROPOSED_LOOKBACKS, _>(|i| (i + 1).min(state_n));
   let mut best_lookback = 1;
   let mut repeating_lookback_idx: usize = 0;
@@ -142,7 +150,7 @@ pub fn choose_lookbacks<L: Latent>(
       i,
       latents,
       &proposed_lookbacks,
-      &mut lookback_counts,
+      &lookback_goodnesses,
     );
     if new_best_lookback != best_lookback {
       repeating_lookback_idx += 1;
@@ -151,7 +159,11 @@ pub fn choose_lookbacks<L: Latent>(
       new_best_lookback;
     best_lookback = new_best_lookback;
     uninit_lookbacks[i - state_n] = MaybeUninit::new(best_lookback as DeltaLookback);
-    lookback_counts[best_lookback - 1] += 1;
+    let count = &mut lookback_counts[best_lookback - 1];
+    *count += 1;
+    if count.is_power_of_two() {
+      lookback_goodnesses[best_lookback - 1] += 1;
+    }
   }
 
   unsafe { lookbacks.set_len(latents.len() - state_n) };


### PR DESCRIPTION
Two changes to significantly improved lookback performance. Changes and bench results look good, but we should do a manual bench too. 

**AI bench summary below**

# Lookback delta search speedup — benchmark results

Measurements backing the two commits:

1. `Speed up lookback delta encoding search` — algorithmic/codegen changes in
   `pco/src/delta/lookback.rs`
2. `Enable lzcnt on x86_64` — adds `+lzcnt` to the documented x86_64 target features

## Setup

| | |
|---|---|
| CPU | AMD Ryzen Threadripper PRO 3975WX (Zen 2, 32C/64T) |
| rustc | 1.97.1 (8bab26f4f 2026-07-14) |
| baseline commit | `aee9bdd` (Python 3.14t (#394)) |
| codec | `pco` at default settings (level 8) |

Three binaries were built into separate target directories with explicit
`RUSTFLAGS`, so the flags of each are unambiguous regardless of
`.cargo/config.toml`:

| variant | source | `RUSTFLAGS` target features |
|---|---|---|
| **main** | `aee9bdd` | `+bmi1,+bmi2,+avx2` |
| **+lookback** | `aee9bdd` + commit 1 | `+bmi1,+bmi2,+avx2` |
| **+lookback+lzcnt** | `aee9bdd` + commits 1 and 2 | `+bmi1,+bmi2,+lzcnt,+avx2` |

Flag application was verified with `objdump`: the `lzcnt` opcode count is 34 /
34 / 331 respectively.

Commands:

```bash
# 28 binary datasets
pcodec bench --iters 15 -c pco --results-csv out.csv

# contrib
pcodec bench -i data/contrib/u64_lomax.bin --input-format binary \
  --input-name u64_lomax --iters 15 -c pco --results-csv out.csv
pcodec bench -i data/contrib/devinrsmith-air-quality.20220714.zstd.parquet \
  --input-name "air quality" --iters 15 -c pco --results-csv out.csv
pcodec bench -i data/contrib/fhvhv_tripdata_2023-04.parquet \
  --input-name taxi --iters 5 -c pco --results-csv out.csv
pcodec bench -i data/contrib/reddit_2022_place_numerical.parquet \
  --input-name "r/place" --iters 5 -c pco --results-csv out.csv
```

The bench reports the median of the iterations and asserts a bitwise round
trip. All runs were sequential with no other load on the machine.

**Compressed sizes were byte-identical across all three variants on all 32
datasets.** Both changes are purely performance; neither alters the format or
the compression ratio.

## Compression — binary datasets (`data/binary`, 15 iterations)

| dataset | main | +lookback | +lookback+lzcnt | lookback % | both % | ratio |
|---|---:|---:|---:|---:|---:|---:|
| `i64_interl1` | 0.862s | 0.582s | 0.543s | -32.4% | -37.0% | 14.77 |
| `i64_interl_scrambl1` | 0.931s | 0.642s | 0.596s | -31.0% | -36.0% | 7.34 |
| `i64_interl0` | 0.893s | 0.630s | 0.593s | -29.5% | -33.6% | 8.96 |
| `f64_diablo` | 0.693s | 0.578s | 0.564s | -16.6% | -18.7% | 4.41 |
| `i64_total_cents` | 0.233s | 0.214s | 0.213s | -8.3% | -8.4% | 6.62 |
| `f64_slow_cosine` | 0.373s | 0.346s | 0.339s | -7.3% | -9.2% | 4.93 |
| `i64_slow_cosine` | 0.141s | 0.133s | 0.129s | -5.9% | -8.4% | 41.88 |
| `i64_cents` | 0.165s | 0.155s | 0.154s | -5.7% | -6.4% | 18.03 |
| `f32_log_normal` | 0.268s | 0.253s | 0.252s | -5.6% | -6.0% | 1.25 |
| `f64_radians` | 0.130s | 0.123s | 0.119s | -5.2% | -8.3% | 78.88 |
| `f32_normal` | 0.263s | 0.250s | 0.251s | -5.2% | -4.7% | 1.21 |
| `i32_lomax05` | 0.232s | 0.220s | 0.229s | -5.1% | -1.1% | 2.31 |
| `i64_sparse` | 0.089s | 0.084s | 0.085s | -4.7% | -4.5% | 781.77 |
| `u32_lomax05` | 0.230s | 0.219s | 0.217s | -4.7% | -5.5% | 2.33 |
| `f32_csum` | 0.251s | 0.240s | 0.236s | -4.2% | -6.0% | 2.11 |
| `f64_integers` | 0.310s | 0.297s | 0.295s | -4.1% | -4.6% | 2.10 |
| `i64_dollars` | 0.166s | 0.159s | 0.160s | -4.0% | -3.4% | 12.92 |
| `f64_normal` | 0.326s | 0.313s | 0.315s | -3.8% | -3.2% | 1.15 |
| `i64_dist_shift` | 0.219s | 0.211s | 0.209s | -3.5% | -4.8% | 3.35 |
| `i64_near_linear` | 0.250s | 0.241s | 0.249s | -3.5% | -0.6% | 2.84 |
| `f64_quantized_normal` | 0.319s | 0.308s | 0.313s | -3.4% | -1.9% | 2.41 |
| `f16_normal` | 0.290s | 0.281s | 0.279s | -3.4% | -3.8% | 1.18 |
| `i64_geo` | 0.225s | 0.219s | 0.216s | -2.7% | -3.9% | 5.59 |
| `i64_lomax05` | 0.234s | 0.228s | 0.230s | -2.5% | -1.6% | 4.63 |
| `f64_decimal` | 0.378s | 0.373s | 0.369s | -1.3% | -2.2% | 4.67 |
| `i64_constant` | 0.032s | 0.032s | 0.032s | -0.9% | -1.7% | 118343.20 |
| `i64_millis` | 0.322s | 0.319s | 0.321s | -0.9% | -0.4% | 2.13 |
| `i64_uniform` | 0.269s | 0.270s | 0.255s | +0.6% | -5.3% | 1.00 |
| **total** | **9.092s** | **7.921s** | **7.762s** | **-12.9%** | **-14.6%** | |

The four big winners (`i64_interl*`, `f64_diablo`) are the datasets that
actually select `Lookback` delta encoding. Every other dataset still gains a
few percent because `choose_lookbacks` is additionally run over a *sample* of
every dataset while choosing a delta encoding.

`i64_uniform` at +0.6% and `i64_constant` at -0.9% are within run-to-run noise;
these are among the cheapest datasets in the suite.

## Compression — contrib datasets

| dataset | iters | main | +lookback | +lookback+lzcnt | lookback % | both % | ratio |
|---|---:|---:|---:|---:|---:|---:|---:|
| `u64_lomax` | 15 | 0.025s | 0.023s | 0.022s | -7.3% | -9.6% | 4.15 |
| `air quality` | 15 | 0.217s | 0.203s | 0.202s | -6.4% | -6.8% | 10.00 |
| `taxi` | 5 | 9.786s | 9.644s | 9.478s | -1.4% | -3.1% | 6.90 |
| `r/place` | 5 | 21.966s | 21.298s | 21.386s | -3.0% | -2.6% | 6.79 |
| **total** | | **31.993s** | **31.168s** | **31.089s** | **-2.6%** | **-2.8%** | |

Gains here are modest because these real-world tabular columns mostly do not
select `Lookback`, so they only benefit from the cheaper delta-selection
sampling pass.

## Compression — overall

| scope | main | +lookback | +lookback+lzcnt | lookback % | both % |
|---|---:|---:|---:|---:|---:|
| binary (28) | 9.092s | 7.921s | 7.762s | -12.9% | -14.6% |
| contrib (4) | 31.993s | 31.168s | 31.089s | -2.6% | -2.8% |
| all (32) | 41.086s | 39.089s | 38.851s | -4.9% | -5.4% |

## Decompression

Neither change touches the decode path, and the totals bear that out:

| scope | main | +lookback | +lookback+lzcnt | lookback % | both % |
|---|---:|---:|---:|---:|---:|
| binary (28) | 2.320s | 2.323s | 2.363s | +0.1% | +1.9% |
| contrib (4) | 8.131s | 8.124s | 8.208s | -0.1% | +0.9% |
| all (32) | 10.451s | 10.447s | 10.571s | -0.0% | +1.2% |

### Caveat on the per-dataset decompression numbers

In the single sequential pass above, the `+lzcnt` variant appeared to regress
decompression on several datasets (`i64_millis` +12.3%, `i64_near_linear`
+10.2%, `i64_geo` +9.9%). This did not reproduce. Re-measuring those four
datasets decompress-only at 25 iterations, with the variants interleaved across
three rounds:

| round | main | +lookback | +lookback+lzcnt |
|---|---:|---:|---:|
| 1 | 311.99ms | 325.96ms | 318.86ms |
| 2 | 328.20ms | 325.29ms | 330.68ms |
| 3 | 328.70ms | 318.35ms | 319.93ms |

The spread within a single variant (main alone spans 312–329ms) exceeds any
difference between variants. The apparent regression was thermal/ordering drift
over the ~35 minute sequential run, not a property of the build. Treat the
per-dataset decompression deltas as noise.

## Note on measurement methodology

Wall-clock differences below roughly 2% are not resolvable on this machine with
`--iters 15`. Two specific traps showed up while producing these numbers:

* Running variants in a fixed order within each round is an ordering confound.
  It manufactured a reproducible-looking 1.9% result that disappeared once the
  order was alternated.
* `perf stat` instruction and branch counts are deterministic to ~0.005% and are
  far better for resolving small effects. Note that `cycles` is *not* stable —
  it varied ~2% run to run here.